### PR TITLE
Parse Rem tokens

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -574,6 +574,7 @@ mod tests {
         assert_eq!(eval_str("max(1., 2., -1)"), Ok(2.));
         assert_eq!(eval_str("min(1., 2., -1)"), Ok(-1.));
         assert_eq!(eval_str("sin(1.) + cos(2.)"), Ok((1f64).sin() + (2f64).cos()));
+        assert_eq!(eval_str("10 % 9"), Ok(10f64 % 9f64));
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -82,6 +82,7 @@ named!(binop<Token>, alt!(
     chain!(tag!("-"),||{Token::Binary(Operation::Minus)}) |
     chain!(tag!("*"),||{Token::Binary(Operation::Times)}) |
     chain!(tag!("/"),||{Token::Binary(Operation::Div)}) |
+    chain!(tag!("%"),||{Token::Binary(Operation::Rem)}) |
     chain!(tag!("^"),||{Token::Binary(Operation::Pow)})
     )
 );
@@ -422,6 +423,9 @@ mod tests {
                            Var("y".into()),
                            RParen,
                        ]));
+
+        assert_eq!(tokenize("2 % 3"),
+                   Ok(vec![Number(2f64), Binary(Rem), Number(3f64)]));
 
         assert_eq!(tokenize("()"), Err(ParseError::UnexpectedToken(1)));
 


### PR DESCRIPTION
I'm pretty sure you meant this to be supported since you did define `Rem` operations, but forgot to add the tokenizer.