### PR TITLE
Simplify the creation of a custom Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ homepage = "https://github.com/rekka/meval-rs"
 keywords = ["math", "parser", "expression", "formula", "evaluator"]
 license = "Unlicense/MIT"
 name = "meval"
+readme = "README.md"
 repository = "https://github.com/rekka/meval-rs"
 version = "0.0.6"
-readme = "README.md"
 
 [dependencies]
+fnv = "1.0.5"
 nom = "1.0.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -159,3 +159,7 @@ command line scripts. For other similar projects see:
 This project is dual-licensed under the Unlicense and MIT licenses.
 
 You may use this code under the terms of either license.
+
+[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
+[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
+[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# meval-rs
-
 [![Build Status](https://travis-ci.org/rekka/meval-rs.svg?branch=master)](https://travis-ci.org/rekka/meval-rs)
 [![](http://meritbadge.herokuapp.com/meval)](https://crates.io/crates/meval)
+
+[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
+[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
+[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html
+
+# meval
 
 This [Rust] crate provides a simple math expression parsing and evaluation. Its main goal is to
 be convenient to use, while allowing for some flexibility. Currently works only with `f64`
@@ -39,8 +43,7 @@ fn main() {
 }
 ```
 
-Need to define a Rust function from an expression? No problem, use
-[`Expr`][Expr]
+Need to define a Rust function from an expression? No problem, use [`Expr`][Expr]
 for this and more:
 
 ```rust
@@ -69,17 +72,22 @@ let r = Some(2.).map(&*func);
 Custom constants and functions? Define a [`Context`][Context]!
 
 ```rust
+use meval::{Expr, Context};
+
 let y = 1.;
-let expr = meval::Expr::from_str("phi(-2 * zeta + x)").unwrap();
+let expr = Expr::from_str("phi(-2 * zeta + x)").unwrap();
 
 // create a context with function definitions and variables
-let ctx = (meval::CustomFunc("phi", |x| x + y), ("zeta", -1.));
-// bind function with builtins as well as custom context
-let func = expr.bind_with_context((meval::builtin(), ctx), "x").unwrap();
+let mut ctx = Context::new(); // built-ins
+ctx.func("phi", |x| x + y)
+   .var("zeta", -1.);
+// bind function with a custom context
+let func = expr.bind_with_context(ctx, "x").unwrap();
 assert_eq!(func(2.), -2. * -1. + 2. + 1.);
 ```
 
-For functions with 2, 3, and N variables use `CustomFunc2`, `CustomFunc3` and `CustomFuncN`
+For functions of 2, 3, and N variables use `Context::func2`, `Context::func3` and
+`Context::funcn`,
 respectively. See [`Context`][Context] for more options.
 
 If you need a custom function depending on mutable parameters, you will need to use a
@@ -87,10 +95,13 @@ If you need a custom function depending on mutable parameters, you will need to 
 
 ```rust
 use std::cell::Cell;
+use meval::{Expr, Context};
 let y = Cell::new(0.);
-let expr = meval::Expr::from_str("phi(x)").unwrap();
+let expr = Expr::from_str("phi(x)").unwrap();
 
-let ctx = meval::CustomFunc("phi", |x| x + y.get());
+let mut ctx = Context::empty(); // no built-ins
+ctx.func("phi", |x| x + y.get());
+
 let func = expr.bind_with_context(ctx, "x").unwrap();
 assert_eq!(func(2.), 2.);
 y.set(3.);
@@ -104,10 +115,12 @@ assert_eq!(func(2.), 5.);
 - binary operators: `+`, `-`, `*`, `/`, `%` (remainder), `^` (power)
 - unary operators: `+`, `-`
 
-It supports custom variables like `x`, `weight`, `C_0`, etc. A variable must start with
-`[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`.
+It supports custom variables and functions like `x`, `weight`, `C_0`, `f(1)`, etc. A variable
+or function name must start with `[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`. Custom
+functions with a variable number of arguments are also supported.
 
-Build-ins (given by context `meval::builtin()`) currently supported:
+Build-ins (given by the context `Context::new()` and when no context provided) currently
+supported:
 
 - functions implemented using functions of the same name in [Rust std library][std-float]:
 
@@ -137,12 +150,12 @@ command line scripts. For other similar projects see:
 [Rust]: https://www.rust-lang.org/
 [std-float]: http://doc.rust-lang.org/stable/std/primitive.f64.html
 
+[Expr]: struct.Expr.html
+[Expr::bind]: struct.Expr.html#method.bind
+[Context]: struct.Context.html
+
 ## License
 
 This project is dual-licensed under the Unlicense and MIT licenses.
 
 You may use this code under the terms of either license.
-
-[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
-[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
-[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,15 @@
+[![Build Status](https://travis-ci.org/rekka/meval-rs.svg?branch=master)](https://travis-ci.org/rekka/meval-rs)
+[![](http://meritbadge.herokuapp.com/meval)](https://crates.io/crates/meval)
+
+[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
+[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
+[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html
+
+{{readme}}
+
+## License
+
+This project is dual-licensed under the Unlicense and MIT licenses.
+
+You may use this code under the terms of either license.
+

--- a/README.tpl
+++ b/README.tpl
@@ -13,3 +13,7 @@ This project is dual-licensed under the Unlicense and MIT licenses.
 
 You may use this code under the terms of either license.
 
+[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
+[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
+[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html
+

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@ extern crate meval;
 
 use test::Bencher;
 use meval::Expr;
-use meval::HashContext;
+use meval::Context;
 
 const EXPR: &'static str = "abs(sin(x + 1) * (x^2 + x + 1))";
 
@@ -28,7 +28,7 @@ fn evaluation(b: &mut Bencher) {
 #[bench]
 fn evaluation_hashcontext(b: &mut Bencher) {
     let expr = Expr::from_str(EXPR).unwrap();
-    let func = expr.bind_with_context(HashContext::new(), "x").unwrap();
+    let func = expr.bind_with_context(Context::new(), "x").unwrap();
     b.iter(|| {
         func(1.);
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,13 +5,14 @@ extern crate meval;
 
 use test::Bencher;
 use meval::Expr;
+use meval::HashContext;
 
 const EXPR: &'static str = "abs(sin(x + 1) * (x^2 + x + 1))";
 
 #[bench]
 fn parsing(b: &mut Bencher) {
     b.iter(|| {
-        Expr::from_str(EXPR);
+        Expr::from_str(EXPR).unwrap();
     });
 }
 
@@ -19,6 +20,15 @@ fn parsing(b: &mut Bencher) {
 fn evaluation(b: &mut Bencher) {
     let expr = Expr::from_str(EXPR).unwrap();
     let func = expr.bind("x").unwrap();
+    b.iter(|| {
+        func(1.);
+    });
+}
+
+#[bench]
+fn evaluation_hashcontext(b: &mut Bencher) {
+    let expr = Expr::from_str(EXPR).unwrap();
+    let func = expr.bind_with_context(HashContext::new(), "x").unwrap();
     b.iter(|| {
         func(1.);
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,6 +6,11 @@ extern crate meval;
 use test::Bencher;
 use meval::Expr;
 use meval::Context;
+use meval::FuncEvalError;
+use meval::min_array;
+use meval::max_array;
+use meval::ContextProvider;
+use std::f64::consts;
 
 const EXPR: &'static str = "abs(sin(x + 1) * (x^2 + x + 1))";
 
@@ -17,9 +22,9 @@ fn parsing(b: &mut Bencher) {
 }
 
 #[bench]
-fn evaluation(b: &mut Bencher) {
+fn evaluation_matchcontext(b: &mut Bencher) {
     let expr = Expr::from_str(EXPR).unwrap();
-    let func = expr.bind("x").unwrap();
+    let func = expr.bind_with_context(MatchBuiltins, "x").unwrap();
     b.iter(|| {
         func(1.);
     });
@@ -32,4 +37,78 @@ fn evaluation_hashcontext(b: &mut Bencher) {
     b.iter(|| {
         func(1.);
     });
+}
+
+macro_rules! one_arg {
+    ($args:expr, $func:ident) => {
+        if $args.len() == 1 {
+            Ok($args[0].$func())
+        } else {
+            Err(FuncEvalError::NumberArgs(1))
+        }
+    }
+}
+
+macro_rules! two_args {
+    ($args:expr, $func:ident) => {
+        if $args.len() == 2 {
+            Ok($args[0].$func($args[1]))
+        } else {
+            Err(FuncEvalError::NumberArgs(2))
+        }
+    }
+}
+
+macro_rules! one_or_more_arg {
+    ($args:expr, $func:ident) => {
+        if $args.len() >= 1 {
+            Ok($func($args))
+        } else {
+            Err(FuncEvalError::TooFewArguments)
+        }
+    }
+}
+
+/// Built-in functions and constants.
+///
+/// See the library documentation for the list of built-ins.
+#[doc(hidden)]
+pub struct MatchBuiltins;
+
+impl ContextProvider for MatchBuiltins {
+    fn get_var(&self, name: &str) -> Option<f64> {
+        match name {
+            "pi" => Some(consts::PI),
+            "e" => Some(consts::E),
+            _ => None,
+        }
+    }
+    fn eval_func(&self, name: &str, args: &[f64]) -> Result<f64, FuncEvalError> {
+        match name {
+            "sqrt" => one_arg!(args, sqrt),
+            "exp" => one_arg!(args, exp),
+            "ln" => one_arg!(args, ln),
+            "abs" => one_arg!(args, abs),
+            "sin" => one_arg!(args, sin),
+            "cos" => one_arg!(args, cos),
+            "tan" => one_arg!(args, tan),
+            "asin" => one_arg!(args, asin),
+            "acos" => one_arg!(args, acos),
+            "atan" => one_arg!(args, atan),
+            "sinh" => one_arg!(args, sinh),
+            "cosh" => one_arg!(args, cosh),
+            "tanh" => one_arg!(args, tanh),
+            "asinh" => one_arg!(args, asinh),
+            "acosh" => one_arg!(args, acosh),
+            "atanh" => one_arg!(args, atanh),
+            "floor" => one_arg!(args, floor),
+            "ceil" => one_arg!(args, ceil),
+            "round" => one_arg!(args, round),
+            "signum" => one_arg!(args, signum),
+            "atan2" => two_args!(args, atan2),
+            "max" => one_or_more_arg!(args, max_array),
+            "min" => one_or_more_arg!(args, min_array),
+            _ => Err(FuncEvalError::UnknownFunction),
+        }
+    }
 }

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -35,8 +35,9 @@ fn main() {
             // create a function of one variable
             let func = match expr.bind("x") {
                 Ok(func) => func,
-                Err(e) =>
-                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e),
+                Err(e) => {
+                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e)
+                }
             };
 
             axes.lines(&xi, xi.iter().map(|&x| func(x)), &[Caption(&arg)]);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,6 +1,8 @@
 use std::ops::Deref;
 use std::f64::consts;
-use std::collections::HashMap;
+use fnv::FnvHashMap;
+
+type ContextHashMap<K, V> = FnvHashMap<K, V>;
 
 use Error;
 use tokenizer::{Token, tokenize};
@@ -607,8 +609,8 @@ macro_rules! arg {
 }
 
 pub struct HashContext<'a> {
-    vars: HashMap<String, f64>,
-    funcs: HashMap<String, GuardedFunc<'a>>,
+    vars: ContextHashMap<String, f64>,
+    funcs: ContextHashMap<String, GuardedFunc<'a>>,
 }
 
 impl<'a> HashContext<'a> {
@@ -645,8 +647,8 @@ impl<'a> HashContext<'a> {
 
     pub fn empty() -> HashContext<'a> {
         HashContext {
-            vars: HashMap::new(),
-            funcs: HashMap::new(),
+            vars: ContextHashMap::default(),
+            funcs: ContextHashMap::default(),
         }
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -368,87 +368,16 @@ impl std::error::Error for FuncEvalError {
     }
 }
 
-/// Built-in functions and constants.
-///
-/// See the library documentation for the list of built-ins.
 #[doc(hidden)]
-pub struct Builtins;
-
-macro_rules! one_arg {
-    ($args:expr, $func:ident) => {
-        if $args.len() == 1 {
-            Ok($args[0].$func())
-        } else {
-            Err(FuncEvalError::NumberArgs(1))
-        }
-    }
-}
-
-macro_rules! two_args {
-    ($args:expr, $func:ident) => {
-        if $args.len() == 2 {
-            Ok($args[0].$func($args[1]))
-        } else {
-            Err(FuncEvalError::NumberArgs(2))
-        }
-    }
-}
-
-macro_rules! one_or_more_arg {
-    ($args:expr, $func:ident) => {
-        if $args.len() >= 1 {
-            Ok($func($args))
-        } else {
-            Err(FuncEvalError::TooFewArguments)
-        }
-    }
-}
-
-fn max_array(xs: &[f64]) -> f64 {
+pub fn max_array(xs: &[f64]) -> f64 {
     xs.iter().fold(::std::f64::NEG_INFINITY, |m, &x| m.max(x))
 }
 
-fn min_array(xs: &[f64]) -> f64 {
+#[doc(hidden)]
+pub fn min_array(xs: &[f64]) -> f64 {
     xs.iter().fold(::std::f64::INFINITY, |m, &x| m.min(x))
 }
 
-impl ContextProvider for Builtins {
-    fn get_var(&self, name: &str) -> Option<f64> {
-        match name {
-            "pi" => Some(consts::PI),
-            "e" => Some(consts::E),
-            _ => None,
-        }
-    }
-    fn eval_func(&self, name: &str, args: &[f64]) -> Result<f64, FuncEvalError> {
-        match name {
-            "sqrt" => one_arg!(args, sqrt),
-            "exp" => one_arg!(args, exp),
-            "ln" => one_arg!(args, ln),
-            "abs" => one_arg!(args, abs),
-            "sin" => one_arg!(args, sin),
-            "cos" => one_arg!(args, cos),
-            "tan" => one_arg!(args, tan),
-            "asin" => one_arg!(args, asin),
-            "acos" => one_arg!(args, acos),
-            "atan" => one_arg!(args, atan),
-            "sinh" => one_arg!(args, sinh),
-            "cosh" => one_arg!(args, cosh),
-            "tanh" => one_arg!(args, tanh),
-            "asinh" => one_arg!(args, asinh),
-            "acosh" => one_arg!(args, acosh),
-            "atanh" => one_arg!(args, atanh),
-            "floor" => one_arg!(args, floor),
-            "ceil" => one_arg!(args, ceil),
-            "round" => one_arg!(args, round),
-            "signum" => one_arg!(args, signum),
-            "atan2" => two_args!(args, atan2),
-            "max" => one_or_more_arg!(args, max_array),
-            "min" => one_or_more_arg!(args, min_array),
-            _ => Err(FuncEvalError::UnknownFunction),
-        }
-    }
-}
 
 /// Returns the built-in constants and functions in a form that can be used as a `ContextProvider`.
 #[doc(hidden)]
@@ -722,8 +651,8 @@ mod tests {
                                          Context::new().func3("phi", |x, y, z| x + y * z)),
                    Ok(2. + 3. * 4.));
         assert_eq!(eval_str_with_context("phi(2., 3.)",
-                                         Context::new().funcn("phi",
-                                                              |xs: &[f64]| xs[0] + xs[1], 2)),
+                                         Context::new()
+                                             .funcn("phi", |xs: &[f64]| xs[0] + xs[1], 2)),
                    Ok(2. + 3.));
         let mut m = HashMap::new();
         m.insert("x", 2.);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@
 
 #[macro_use]
 extern crate nom;
+extern crate fnv;
 
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,28 @@
 //! This [Rust] crate provides a simple math expression parsing and evaluation. Its main goal is to
 //! be convenient to use, while allowing for some flexibility. Currently works only with `f64`
-//! types.
+//! types. A typical use case is the configuration of numerical computations in
+//! Rust, think initial data and boundary conditions, via config files or command line arguments.
 //!
-//! ## Simple examples
+//! # Documentation
+//!
+//! [Full API documentation](http://rekka.github.io/meval-rs/meval/index.html)
+//!
+//! # Installation
+//!
+//! Simply add the corresponding entry to your `Cargo.toml` dependency list:
+//!
+//! ```toml
+//! [dependencies]
+//! meval = "0.0.6"
+//! ```
+//!
+//! and add this to your crate root:
+//!
+//! ```rust
+//! extern crate meval;
+//! ```
+//!
+//! # Simple examples
 //!
 //! ```rust
 //! extern crate meval;
@@ -79,7 +99,7 @@
 //! assert_eq!(func(2.), 5.);
 //! ```
 //!
-//! ## Supported expressions
+//! # Supported expressions
 //!
 //! `meval` supports basic mathematical operations on floating point numbers:
 //!
@@ -111,7 +131,7 @@
 //!     - `pi`
 //!     - `e`
 //!
-//! ## Related projects
+//! # Related projects
 //!
 //! This is a toy project of mine for learning Rust, and to be hopefully useful when writing
 //! command line scripts. For other similar projects see:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,17 +43,22 @@
 //! Custom constants and functions? Define a [`Context`][Context]!
 //!
 //! ```rust
+//! use meval::{Expr, Context};
+//!
 //! let y = 1.;
-//! let expr = meval::Expr::from_str("phi(-2 * zeta + x)").unwrap();
+//! let expr = Expr::from_str("phi(-2 * zeta + x)").unwrap();
 //!
 //! // create a context with function definitions and variables
-//! let ctx = (meval::CustomFunc("phi", |x| x + y), ("zeta", -1.));
-//! // bind function with builtins as well as custom context
-//! let func = expr.bind_with_context((meval::builtin(), ctx), "x").unwrap();
+//! let mut ctx = Context::new(); // built-ins
+//! ctx.func("phi", |x| x + y)
+//!    .var("zeta", -1.);
+//! // bind function with a custom context
+//! let func = expr.bind_with_context(ctx, "x").unwrap();
 //! assert_eq!(func(2.), -2. * -1. + 2. + 1.);
 //! ```
 //!
-//! For functions with 2, 3, and N variables use `CustomFunc2`, `CustomFunc3` and `CustomFuncN`
+//! For functions of 2, 3, and N variables use `Context::func2`, `Context::func3` and
+//! `Context::funcn`,
 //! respectively. See [`Context`][Context] for more options.
 //!
 //! If you need a custom function depending on mutable parameters, you will need to use a
@@ -61,10 +66,13 @@
 //!
 //! ```rust
 //! use std::cell::Cell;
+//! use meval::{Expr, Context};
 //! let y = Cell::new(0.);
-//! let expr = meval::Expr::from_str("phi(x)").unwrap();
+//! let expr = Expr::from_str("phi(x)").unwrap();
 //!
-//! let ctx = meval::CustomFunc("phi", |x| x + y.get());
+//! let mut ctx = Context::empty(); // no built-ins
+//! ctx.func("phi", |x| x + y.get());
+//!
 //! let func = expr.bind_with_context(ctx, "x").unwrap();
 //! assert_eq!(func(2.), 2.);
 //! y.set(3.);
@@ -78,10 +86,12 @@
 //! - binary operators: `+`, `-`, `*`, `/`, `%` (remainder), `^` (power)
 //! - unary operators: `+`, `-`
 //!
-//! It supports custom variables like `x`, `weight`, `C_0`, etc. A variable must start with
-//! `[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`.
+//! It supports custom variables and functions like `x`, `weight`, `C_0`, `f(1)`, etc. A variable
+//! or function name must start with `[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`. Custom
+//! functions with a variable number of arguments are also supported.
 //!
-//! Build-ins (given by context `meval::builtin()`) currently supported:
+//! Build-ins (given by the context `Context::new()` and when no context provided) currently
+//! supported:
 //!
 //! - functions implemented using functions of the same name in [Rust std library][std-float]:
 //!
@@ -113,7 +123,7 @@
 //!
 //! [Expr]: struct.Expr.html
 //! [Expr::bind]: struct.Expr.html#method.bind
-//! [Context]: trait.Context.html
+//! [Context]: struct.Context.html
 
 #[macro_use]
 extern crate nom;

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -232,10 +232,15 @@ mod tests {
                             Number(2f64),
                             RParen,
                             RParen]),
-                   Ok(vec![Number(1f64), Func("sin".into(), Some(1)), Number(2f64), Func("cos".into(), Some(1)), Func("max".into(), Some(2))]));
+                   Ok(vec![Number(1f64),
+                           Func("sin".into(), Some(1)),
+                           Number(2f64),
+                           Func("cos".into(), Some(1)),
+                           Func("max".into(), Some(2))]));
 
         assert_eq!(to_rpn(&[Binary(Plus)]), Err(RPNError::NotEnoughOperands(0)));
-        assert_eq!(to_rpn(&[Func("f".into(), None), Binary(Plus), RParen]), Err(RPNError::NotEnoughOperands(0)));
+        assert_eq!(to_rpn(&[Func("f".into(), None), Binary(Plus), RParen]),
+                   Err(RPNError::NotEnoughOperands(0)));
         assert_eq!(to_rpn(&[Var("x".into()), Number(1.)]),
                    Err(RPNError::TooManyOperands));
         assert_eq!(to_rpn(&[LParen]), Err(RPNError::MismatchedLParen(0)));
@@ -243,7 +248,9 @@ mod tests {
         assert_eq!(to_rpn(&[Func("sin".into(), None)]),
                    Err(RPNError::MismatchedLParen(0)));
         assert_eq!(to_rpn(&[Comma]), Err(RPNError::UnexpectedComma(0)));
-        assert_eq!(to_rpn(&[Func("f".into(), None), Comma]), Err(RPNError::MismatchedLParen(0)));
-        assert_eq!(to_rpn(&[Func("f".into(), None), LParen, Comma, RParen]), Err(RPNError::UnexpectedComma(2)));
+        assert_eq!(to_rpn(&[Func("f".into(), None), Comma]),
+                   Err(RPNError::MismatchedLParen(0)));
+        assert_eq!(to_rpn(&[Func("f".into(), None), LParen, Comma, RParen]),
+                   Err(RPNError::UnexpectedComma(2)));
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -31,11 +31,7 @@ impl fmt::Display for ParseError {
                 write!(f,
                        "Missing {} right parenthes{}.",
                        i,
-                       if i == 1 {
-                           "is"
-                       } else {
-                           "es"
-                       })
+                       if i == 1 { "is" } else { "es" })
             }
             ParseError::MissingArgument => write!(f, "Missing argument at the end of expression."),
         }
@@ -167,7 +163,8 @@ fn digit_complete(input: &[u8]) -> IResult<&[u8], &[u8]> {
 
 named!(float<usize>, chain!(
         a: digit_complete ~
-        b: complete!(chain!(tag!(".") ~ d: digit_complete?,||{1 + d.map(|s| s.len()).unwrap_or(0)}))? ~
+        b: complete!(chain!(tag!(".") ~ d: digit_complete?,
+                            ||{1 + d.map(|s| s.len()).unwrap_or(0)}))? ~
         e: complete!(exp),
         ||{a.len() + b.unwrap_or(0) + e.unwrap_or(0)}
     )
@@ -347,7 +344,8 @@ mod tests {
     fn test_func() {
         for &s in ["abc(", "u0(", "_034 (", "A_be45EA  ("].iter() {
             assert_eq!(func(s.as_bytes()),
-                       IResult::Done(&b""[..], Token::Func((&s[0..s.len() - 1]).trim().into(), None)));
+                       IResult::Done(&b""[..],
+                                     Token::Func((&s[0..s.len() - 1]).trim().into(), None)));
         }
 
         assert_eq!(func(b""), IResult::Error(Position(Complete, &b""[..])));


### PR DESCRIPTION
`Context` is now a `struct`. `Context` with builtins is created by `Context::new()`. Builder pattern is supported for adding additional variables and functions.

`builtin()` and `CustomFunc*` have been removed.