### PR TITLE
Api improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ version = "0.0.7"
 [dependencies]
 fnv = "1.0.5"
 nom = "1.0.0"
+serde = { version = "0.9", optional = true }
 
 [dev-dependencies]
 gnuplot = "0.0.18"
+serde_test = "0.9"
+serde_json = "0.9"
+
+[features]
+default = ["serde"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ serde = { version = "0.9", optional = true }
 [dev-dependencies]
 gnuplot = "0.0.18"
 serde_test = "0.9"
-serde_json = "0.9"
+serde_derive = "0.9"
+toml = "0.3"
 
 [features]
 default = ["serde"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ for this and more:
 extern crate meval;
 
 fn main() {
-    let expr = meval::Expr::from_str("sin(pi * x)").unwrap();
+    let expr: meval::Expr = "sin(pi * x)".parse().unwrap();
     let func = expr.bind("x").unwrap();
 
     let vs: Vec<_> = (0..100+1).map(|i| func(i as f64 / 100.)).collect();
@@ -68,7 +68,7 @@ convenient than an unboxed closure since `Box<Fn(f64) -> f64>` does not implemen
 has to be manually dereferenced:
 
 ```rust
-let func = meval::Expr::from_str("x").unwrap().bind("x").unwrap();
+let func = "x".parse::<meval::Expr>().unwrap().bind("x").unwrap();
 let r = Some(2.).map(&*func);
 ```
 
@@ -78,7 +78,7 @@ Custom constants and functions? Define a [`Context`][Context]!
 use meval::{Expr, Context};
 
 let y = 1.;
-let expr = Expr::from_str("phi(-2 * zeta + x)").unwrap();
+let expr: Expr = "phi(-2 * zeta + x)".parse().unwrap();
 
 // create a context with function definitions and variables
 let mut ctx = Context::new(); // built-ins
@@ -100,7 +100,7 @@ If you need a custom function depending on mutable parameters, you will need to 
 use std::cell::Cell;
 use meval::{Expr, Context};
 let y = Cell::new(0.);
-let expr = Expr::from_str("phi(x)").unwrap();
+let expr: Expr = "phi(x)".parse().unwrap();
 
 let mut ctx = Context::empty(); // no built-ins
 ctx.func("phi", |x| x + y.get());
@@ -143,6 +143,42 @@ supported:
     - `pi`
     - `e`
 
+## Deserialization
+
+[`Expr`][Expr] supports deserialization using the [serde] library to make flexible
+configuration easy to set up.
+
+```rust
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+extern crate meval;
+use meval::{Expr, Context};
+
+#[derive(Deserialize)]
+struct Ode {
+    #[serde(deserialize_with = "meval::de::as_f64")]
+    x0: f64,
+    #[serde(deserialize_with = "meval::de::as_f64")]
+    t0: f64,
+    f: Expr,
+}
+
+fn main() {
+    let config = r#"
+        x0 = "cos(1.)"
+        t0 = 2
+        f = "sin(x)"
+    "#;
+    let ode: Ode = toml::from_str(config).unwrap();
+
+    assert_eq!(ode.x0, 1f64.cos());
+    assert_eq!(ode.t0, 2f64);
+    assert_eq!(ode.f.bind("x").unwrap()(2.), 2f64.sin());
+}
+
+```
+
 ## Related projects
 
 This is a toy project of mine for learning Rust, and to be hopefully useful when writing
@@ -156,6 +192,7 @@ command line scripts. For other similar projects see:
 [Expr]: struct.Expr.html
 [Expr::bind]: struct.Expr.html#method.bind
 [Context]: struct.Context.html
+[serde]: https://crates.io/crates/serde
 
 ## License
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -17,13 +17,13 @@ const EXPR: &'static str = "abs(sin(x + 1) * (x^2 + x + 1))";
 #[bench]
 fn parsing(b: &mut Bencher) {
     b.iter(|| {
-        Expr::from_str(EXPR).unwrap();
+        EXPR.parse::<Expr>().unwrap();
     });
 }
 
 #[bench]
 fn evaluation_matchcontext(b: &mut Bencher) {
-    let expr = Expr::from_str(EXPR).unwrap();
+    let expr: Expr = EXPR.parse().unwrap();
     let func = expr.bind_with_context(MatchBuiltins, "x").unwrap();
     b.iter(|| {
         func(1.);
@@ -32,7 +32,7 @@ fn evaluation_matchcontext(b: &mut Bencher) {
 
 #[bench]
 fn evaluation_hashcontext(b: &mut Bencher) {
-    let expr = Expr::from_str(EXPR).unwrap();
+    let expr: Expr = EXPR.parse().unwrap();
     let func = expr.bind_with_context(Context::new(), "x").unwrap();
     b.iter(|| {
         func(1.);
@@ -41,9 +41,9 @@ fn evaluation_hashcontext(b: &mut Bencher) {
 
 #[bench]
 fn default_context(b: &mut Bencher) {
-    let expr = Expr::from_str("1 + 2 * 3").unwrap();
+    let expr: Expr = "1 + 2 * 3".parse().unwrap();
     b.iter(|| {
-        expr.eval(Context::default())
+        expr.eval()
     });
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -39,6 +39,14 @@ fn evaluation_hashcontext(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn default_context(b: &mut Bencher) {
+    let expr = Expr::from_str("1 + 2 * 3").unwrap();
+    b.iter(|| {
+        expr.eval(Context::default())
+    });
+}
+
 macro_rules! one_arg {
     ($args:expr, $func:ident) => {
         if $args.len() == 1 {

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -28,7 +28,7 @@ fn main() {
 
         for arg in args {
             // parse expression
-            let expr = match Expr::from_str(&arg) {
+            let expr = match arg.parse::<Expr>() {
                 Ok(expr) => expr,
                 Err(e) => return println!("Error when evaluating `{}`: {}", arg, e),
             };

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,0 +1,36 @@
+//! Deserialization utilities.
+use serde::de;
+use serde::de::Error;
+use serde::Deserialize;
+use super::Expr;
+
+/// Deserialize into [`Expr`](../struct.Expr.html) and then evaluate using `Expr::eval`.
+///
+/// # Example
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate serde_derive;
+/// extern crate toml;
+/// extern crate meval;
+/// use meval::{Expr, Context};
+///
+/// #[derive(Deserialize)]
+/// struct Foo {
+///     #[serde(deserialize_with = "meval::de::as_f64")]
+///     x: f64,
+/// }
+///
+/// fn main() {
+///     let foo: Foo = toml::from_str(r#" x = "cos(1.)" "#).unwrap();
+///     assert_eq!(foo.x, 1f64.cos());
+///
+///     let foo: Result<Foo, _> = toml::from_str(r#" x = "cos(x)" "#);
+///     assert!(foo.is_err());
+/// }
+/// ```
+///
+/// See [crate root](../index.html#deserialization) for another example.
+pub fn as_f64<D: de::Deserializer>(deserializer: D) -> Result<f64, D::Error> {
+    Expr::deserialize(deserializer)?.eval().map_err(D::Error::custom)
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -612,6 +612,12 @@ impl<'a> Context<'a> {
     }
 }
 
+impl<'a> Default for Context<'a> {
+    fn default() -> Self {
+        Context::new()
+    }
+}
+
 type GuardedFunc<'a> = Box<Fn(&[f64]) -> Result<f64, FuncEvalError> + 'a>;
 
 /// Trait for types that can specify the number of required arguments for a function with a

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -495,6 +495,7 @@ array_impls! {
 /// assert_eq!(eval_str_with_context("pi + sum(1., 2.) + f(x)", &ctx),
 ///            Ok(std::f64::consts::PI + 1. + 2. + 2. * 3.));
 /// ```
+#[derive(Clone)]
 pub struct Context<'a> {
     vars: ContextHashMap<String, f64>,
     funcs: ContextHashMap<String, GuardedFunc<'a>>,
@@ -503,34 +504,38 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Creates a context with built-in constants and functions.
     pub fn new() -> Context<'a> {
-        let mut ctx = Context::empty();
-        ctx.var("pi", consts::PI);
-        ctx.var("e", consts::E);
+        thread_local!(static DEFAULT_CONTEXT: Context<'static> = {
+            let mut ctx = Context::empty();
+            ctx.var("pi", consts::PI);
+            ctx.var("e", consts::E);
 
-        ctx.func("sqrt", f64::sqrt);
-        ctx.func("exp", f64::exp);
-        ctx.func("ln", f64::ln);
-        ctx.func("abs", f64::abs);
-        ctx.func("sin", f64::sin);
-        ctx.func("cos", f64::cos);
-        ctx.func("tan", f64::tan);
-        ctx.func("asin", f64::asin);
-        ctx.func("acos", f64::acos);
-        ctx.func("atan", f64::atan);
-        ctx.func("sinh", f64::sinh);
-        ctx.func("cosh", f64::cosh);
-        ctx.func("tanh", f64::tanh);
-        ctx.func("asinh", f64::asinh);
-        ctx.func("acosh", f64::acosh);
-        ctx.func("atanh", f64::atanh);
-        ctx.func("floor", f64::floor);
-        ctx.func("ceil", f64::ceil);
-        ctx.func("round", f64::round);
-        ctx.func("signum", f64::signum);
-        ctx.func2("atan2", f64::atan2);
-        ctx.funcn("max", max_array, 1..);
-        ctx.funcn("min", min_array, 1..);
-        ctx
+            ctx.func("sqrt", f64::sqrt);
+            ctx.func("exp", f64::exp);
+            ctx.func("ln", f64::ln);
+            ctx.func("abs", f64::abs);
+            ctx.func("sin", f64::sin);
+            ctx.func("cos", f64::cos);
+            ctx.func("tan", f64::tan);
+            ctx.func("asin", f64::asin);
+            ctx.func("acos", f64::acos);
+            ctx.func("atan", f64::atan);
+            ctx.func("sinh", f64::sinh);
+            ctx.func("cosh", f64::cosh);
+            ctx.func("tanh", f64::tanh);
+            ctx.func("asinh", f64::asinh);
+            ctx.func("acosh", f64::acosh);
+            ctx.func("atanh", f64::atanh);
+            ctx.func("floor", f64::floor);
+            ctx.func("ceil", f64::ceil);
+            ctx.func("round", f64::round);
+            ctx.func("signum", f64::signum);
+            ctx.func2("atan2", f64::atan2);
+            ctx.funcn("max", max_array, 1..);
+            ctx.funcn("min", min_array, 1..);
+            ctx
+        });
+
+        DEFAULT_CONTEXT.with(|ctx| ctx.clone())
     }
 
     /// Creates an empty contexts.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -12,8 +12,8 @@ use std;
 
 /// Representation of a parsed expression.
 ///
-/// The expression is internally stored in [reverse Polish notation (RPN)][RPN] as a sequence of
-/// `Token`s.
+/// The expression is internally stored in the [reverse Polish notation (RPN)][RPN] as a sequence
+/// of `Token`s.
 ///
 /// Methods `bind`, `bind_with_context`, `bind2`, ... can be used to create (boxed) closures from
 /// the expression that then can be passed around and used as any other `Fn` closures.  A boxed
@@ -22,8 +22,9 @@ use std;
 /// function argument where a closure is expected, it has to be manually dereferenced:
 ///
 /// ```rust
-/// let func = meval::Expr::from_str("x").unwrap().bind("x").unwrap();
+/// let func = meval::Expr::from_str("x^2").unwrap().bind("x").unwrap();
 /// let r = Some(2.).map(&*func);
+/// assert_eq!(r, Some(4.));
 /// ```
 ///
 /// [RPN]: https://en.wikipedia.org/wiki/Reverse_Polish_notation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! extern crate meval;
 //!
 //! fn main() {
-//!     let expr = meval::Expr::from_str("sin(pi * x)").unwrap();
+//!     let expr: meval::Expr = "sin(pi * x)".parse().unwrap();
 //!     let func = expr.bind("x").unwrap();
 //!
 //!     let vs: Vec<_> = (0..100+1).map(|i| func(i as f64 / 100.)).collect();
@@ -58,7 +58,7 @@
 //! has to be manually dereferenced:
 //!
 //! ```rust
-//! let func = meval::Expr::from_str("x").unwrap().bind("x").unwrap();
+//! let func = "x".parse::<meval::Expr>().unwrap().bind("x").unwrap();
 //! let r = Some(2.).map(&*func);
 //! ```
 //!
@@ -68,7 +68,7 @@
 //! use meval::{Expr, Context};
 //!
 //! let y = 1.;
-//! let expr = Expr::from_str("phi(-2 * zeta + x)").unwrap();
+//! let expr: Expr = "phi(-2 * zeta + x)".parse().unwrap();
 //!
 //! // create a context with function definitions and variables
 //! let mut ctx = Context::new(); // built-ins
@@ -90,7 +90,7 @@
 //! use std::cell::Cell;
 //! use meval::{Expr, Context};
 //! let y = Cell::new(0.);
-//! let expr = Expr::from_str("phi(x)").unwrap();
+//! let expr: Expr = "phi(x)".parse().unwrap();
 //!
 //! let mut ctx = Context::empty(); // no built-ins
 //! ctx.func("phi", |x| x + y.get());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,16 +135,36 @@
 //!
 //! # Deserialization
 //!
-//! [`Expr`][Expr] supports deserialization using the [serde] library.
+//! [`Expr`][Expr] supports deserialization using the [serde] library to make flexible
+//! configuration easy to set up.
 //!
 //! ```rust
-//! extern crate serde_json;
+//! #[macro_use]
+//! extern crate serde_derive;
+//! extern crate toml;
 //! extern crate meval;
 //! use meval::{Expr, Context};
 //!
+//! #[derive(Deserialize)]
+//! struct Ode {
+//!     #[serde(deserialize_with = "meval::de::as_f64")]
+//!     x0: f64,
+//!     #[serde(deserialize_with = "meval::de::as_f64")]
+//!     t0: f64,
+//!     f: Expr,
+//! }
+//!
 //! fn main() {
-//!     let p: Expr = serde_json::from_str(r#""2 + 3""#).unwrap();
-//!     assert_eq!(p.eval().unwrap(), 5.);
+//!     let config = r#"
+//!         x0 = "cos(1.)"
+//!         t0 = 2
+//!         f = "sin(x)"
+//!     "#;
+//!     let ode: Ode = toml::from_str(config).unwrap();
+//!
+//!     assert_eq!(ode.x0, 1f64.cos());
+//!     assert_eq!(ode.t0, 2f64);
+//!     assert_eq!(ode.f.bind("x").unwrap()(2.), 2f64.sin());
 //! }
 //!
 //! ```
@@ -177,6 +197,7 @@ use std::fmt;
 pub mod tokenizer;
 pub mod shunting_yard;
 mod expr;
+pub mod de;
 
 pub use expr::*;
 pub use shunting_yard::RPNError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,22 @@
 //!     - `pi`
 //!     - `e`
 //!
+//! # Deserialization
+//!
+//! [`Expr`][Expr] supports deserialization using the [serde] library.
+//!
+//! ```rust
+//! extern crate serde_json;
+//! extern crate meval;
+//! use meval::{Expr, Context};
+//!
+//! fn main() {
+//!     let p: Expr = serde_json::from_str(r#""2 + 3""#).unwrap();
+//!     assert_eq!(p.eval(Context::new()).unwrap(), 5.);
+//! }
+//!
+//! ```
+//!
 //! # Related projects
 //!
 //! This is a toy project of mine for learning Rust, and to be hopefully useful when writing
@@ -146,10 +162,15 @@
 //! [Expr]: struct.Expr.html
 //! [Expr::bind]: struct.Expr.html#method.bind
 //! [Context]: struct.Context.html
+//! [serde]: https://crates.io/crates/serde
 
 #[macro_use]
 extern crate nom;
 extern crate fnv;
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(test)]
+extern crate serde_test;
 
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@
 //!
 //! fn main() {
 //!     let p: Expr = serde_json::from_str(r#""2 + 3""#).unwrap();
-//!     assert_eq!(p.eval(Context::new()).unwrap(), 5.);
+//!     assert_eq!(p.eval().unwrap(), 5.);
 //! }
 //!
 //! ```


### PR DESCRIPTION
- added serde deserialization
- api change: `Expr::eval` is now `Expr::eval_with_context`
- `Expr` implements `FromStr`: use it as "1 + 2".parse::<Expr>()
- added `de::as_f64` for convenient deserialization
- `Context` is now `Clone`