### PR TITLE
Add factorial and log10

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ assert_eq!(func(2.), 5.);
 `meval` supports basic mathematical operations on floating point numbers:
 
 - binary operators: `+`, `-`, `*`, `/`, `%` (remainder), `^` (power)
-- unary operators: `+`, `-`
+- unary operators: `+`, `-`, `!` (factorial)
 
 It supports custom variables and functions like `x`, `weight`, `C_0`, `f(1)`, etc. A variable
 or function name must start with `[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`. Custom

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ supported:
 - functions implemented using functions of the same name in [Rust std library][std-float]:
 
     - `sqrt`, `abs`
-    - `exp`, `ln`
+    - `exp`, `ln`, `log10`
     - `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`
     - `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`
     - `floor`, `ceil`, `round`

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -36,7 +36,7 @@ fn main() {
             let func = match expr.bind("x") {
                 Ok(func) => func,
                 Err(e) => {
-                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e)
+                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e);
                 }
             };
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -6,11 +6,11 @@ use std::str::FromStr;
 
 type ContextHashMap<K, V> = FnvHashMap<K, V>;
 
+use extra_math::factorial;
 use shunting_yard::to_rpn;
 use std;
 use std::fmt;
 use tokenizer::{tokenize, Token};
-use extra_math::factorial;
 use Error;
 
 /// Representation of a parsed expression.
@@ -66,7 +66,12 @@ impl Expr {
                         Div => left / right,
                         Rem => left % right,
                         Pow => left.powf(right),
-                        _ => return Err(Error::EvalError(format!("Unimplemented binary operation: {:?}", op))),
+                        _ => {
+                            return Err(Error::EvalError(format!(
+                                "Unimplemented binary operation: {:?}",
+                                op
+                            )));
+                        }
                     };
                     stack.push(r);
                 }
@@ -79,10 +84,15 @@ impl Expr {
                             // Check to make sure x has no fractional component (can be converted to int without loss)
                             match factorial(x) {
                                 Ok(res) => res,
-                                Err(e) => return Err(Error::EvalError(String::from(e)))
+                                Err(e) => return Err(Error::EvalError(String::from(e))),
                             }
                         }
-                        _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
+                        _ => {
+                            return Err(Error::EvalError(format!(
+                                "Unimplemented unary operation: {:?}",
+                                op
+                            )));
+                        }
                     };
                     stack.push(r);
                 }
@@ -92,7 +102,7 @@ impl Expr {
                             "eval: stack does not have enough arguments for function token \
                              {:?}",
                             token
-                        )))
+                        )));
                     }
                     match ctx.eval_func(n, &stack[stack.len() - i..]) {
                         Ok(r) => {
@@ -109,7 +119,10 @@ impl Expr {
 
         let r = stack.pop().expect("Stack is empty, this is impossible.");
         if !stack.is_empty() {
-            return Err(Error::EvalError(format!("There are still {} items on the stack.", stack.len())))
+            return Err(Error::EvalError(format!(
+                "There are still {} items on the stack.",
+                stack.len()
+            )));
         }
         Ok(r)
     }
@@ -344,7 +357,8 @@ impl Expr {
                     (&var5, x5),
                 ],
                 &ctx,
-            )).expect("Expr::bind5")
+            ))
+            .expect("Expr::bind5")
         })
     }
 
@@ -375,14 +389,12 @@ impl Expr {
         C: ContextProvider + 'a,
     {
         let n = vars.len();
-        try!(
-            self.check_context((
-                vars.into_iter()
-                    .zip(vec![0.; n].into_iter())
-                    .collect::<Vec<_>>(),
-                &ctx
-            ))
-        );
+        try!(self.check_context((
+            vars.into_iter()
+                .zip(vec![0.; n].into_iter())
+                .collect::<Vec<_>>(),
+            &ctx
+        )));
         let vars = vars.iter().map(|v| v.to_owned()).collect::<Vec<_>>();
         Ok(move |x: &[f64]| {
             self.eval_with_context((
@@ -391,7 +403,8 @@ impl Expr {
                     .map(|(v, x)| (v, *x))
                     .collect::<Vec<_>>(),
                 &ctx,
-            )).expect("Expr::bindn")
+            ))
+            .expect("Expr::bindn")
         })
     }
 
@@ -415,7 +428,10 @@ impl Expr {
                     }
                 }
                 Token::Func(_, None) => {
-                    return Err(Error::EvalError(format!("expr::check_context: Unexpected token: {:?}", *t)))
+                    return Err(Error::EvalError(format!(
+                        "expr::check_context: Unexpected token: {:?}",
+                        *t
+                    )));
                 }
                 Token::LParen
                 | Token::RParen
@@ -1069,7 +1085,7 @@ mod tests {
         assert_eq!(eval_str("10 % 9"), Ok(10f64 % 9f64));
 
         match eval_str("0.5!") {
-            Err(Error::EvalError(_)) => {},
+            Err(Error::EvalError(_)) => {}
             _ => panic!("Cannot evaluate factorial of non-integer"),
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -79,10 +79,10 @@ impl Expr {
                             // Check to make sure x has no fractional component (can be converted to int without loss)
                             if x.fract() != 0. || x < 0. {
                                 return Err(Error::EvalError(format!("({})! cannot be evaluated. Must be a non-negative integer!", x)))
-                            } else if x > 20. {
+                            } else if x > 170. {
                                 std::f64::INFINITY
                             } else {
-                                factorial(x as u64) as f64
+                                factorial(x)
                             }
                         }
                         _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
@@ -1057,7 +1057,10 @@ mod tests {
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
         assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
-        assert_eq!(eval_str("25!"), Ok(std::f64::INFINITY));
+        assert_eq!(eval_str("170!"), Ok(7.257415615307994e306));
+        assert_eq!(eval_str("171!"), Ok(std::f64::INFINITY));
+        assert_eq!(eval_str("-171!"), Ok(std::f64::NEG_INFINITY));
+        assert_eq!(eval_str("150!/148!"), Ok(22350.));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -698,6 +698,7 @@ impl<'a> Context<'a> {
             ctx.func("sqrt", f64::sqrt);
             ctx.func("exp", f64::exp);
             ctx.func("ln", f64::ln);
+            ctx.func("log10", f64::log10);
             ctx.func("abs", f64::abs);
             ctx.func("sin", f64::sin);
             ctx.func("cos", f64::cos);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1057,6 +1057,7 @@ mod tests {
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
         assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
+        assert_eq!(eval_str("25!"), Ok(std::f64::INFINITY));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -10,6 +10,7 @@ use shunting_yard::to_rpn;
 use std;
 use std::fmt;
 use tokenizer::{tokenize, Token};
+use extra_math::factorial;
 use Error;
 
 /// Representation of a parsed expression.
@@ -65,24 +66,36 @@ impl Expr {
                         Div => left / right,
                         Rem => left % right,
                         Pow => left.powf(right),
+                        _ => panic!("Unimplemented binary operation: {:?}", op),
                     };
                     stack.push(r);
                 }
                 Unary(op) => {
                     let x = stack.pop().unwrap();
-                    match op {
-                        Plus => stack.push(x),
-                        Minus => stack.push(-x),
-                        _ => panic!("Unimplement unary operation: {:?}", op),
-                    }
+                    let r = match op {
+                        Plus => x,
+                        Minus => -x,
+                        Fact => {
+                            // Check to make sure x has no fractional component (can be converted to int without loss)
+                            if x.fract() != 0. || x < 0. {
+                                return Err(Error::EvalError(format!("({})! cannot be evaluated. Must be a non-negative integer!", x)))
+                            } else if x > 20. {
+                                std::f64::INFINITY
+                            } else {
+                                factorial(x as u64) as f64
+                            }
+                        }
+                        _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
+                    };
+                    stack.push(r);
                 }
                 Func(ref n, Some(i)) => {
                     if stack.len() < i {
-                        panic!(
+                        return Err(Error::EvalError(format!(
                             "eval: stack does not have enough arguments for function token \
                              {:?}",
                             token
-                        );
+                        )))
                     }
                     match ctx.eval_func(n, &stack[stack.len() - i..]) {
                         Ok(r) => {
@@ -93,13 +106,13 @@ impl Expr {
                         Err(e) => return Err(Error::Function(n.to_owned(), e)),
                     }
                 }
-                _ => panic!("Unrecognized token: {:?}", token),
+                _ => return Err(Error::EvalError(format!("Unrecognized token: {:?}", token))),
             }
         }
 
         let r = stack.pop().expect("Stack is empty, this is impossible.");
         if !stack.is_empty() {
-            panic!("There are still {} items on the stack.", stack.len());
+            return Err(Error::EvalError(format!("There are still {} items on the stack.", stack.len())))
         }
         Ok(r)
     }
@@ -405,7 +418,7 @@ impl Expr {
                     }
                 }
                 Token::Func(_, None) => {
-                    panic!("expr::check_context: Unexpected token: {:?}", *t);
+                    return Err(Error::EvalError(format!("expr::check_context: Unexpected token: {:?}", *t)))
                 }
                 Token::LParen
                 | Token::RParen
@@ -1043,6 +1056,7 @@ mod tests {
         assert_eq!(eval_str("2 + 3"), Ok(5.));
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
+        assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));
@@ -1054,6 +1068,16 @@ mod tests {
             Ok((1f64).sin() + (2f64).cos())
         );
         assert_eq!(eval_str("10 % 9"), Ok(10f64 % 9f64));
+
+        match eval_str("(-2)!") {
+            Err(Error::EvalError(_)) => {},
+            _ => panic!("Cannot evaluate factorial of -2"),
+        }
+
+        match eval_str("0.5!") {
+            Err(Error::EvalError(_)) => {},
+            _ => panic!("Cannot evaluate factorial of non-integer"),
+        }
     }
 
     #[test]

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,12 +1,22 @@
 // Why the heck does factorial take a float?
 // This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
-pub fn factorial(num: f64) -> f64 {
+fn factorial_unsafe(num: f64) -> f64 {
 	if num == 0. ||
 		num == 1. {
 		return 1.;
 	} else {
-		return num * factorial(num - 1.);
+		return num * factorial_unsafe(num - 1.);
 	}
+}
+
+pub fn factorial(num: f64) -> Result<f64, &'static str> {
+  if num.fract() != 0. || num < 0. {
+    return Err("Number must be non-negative with no fractional component!")
+  } else if num > 170. {
+    return Ok(std::f64::INFINITY)
+  } else {
+    return Ok(factorial_unsafe(num))
+  }
 }
 
 #[cfg(test)]
@@ -15,10 +25,21 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0.), 1.);
-      assert_eq!(factorial(1.), 1.);
-      assert_eq!(factorial(2.), 2.);
-      assert_eq!(factorial(3.), 6.);
-      assert_eq!(factorial(4.), 24.);
+      assert_eq!(factorial(0.), Ok(1.));
+      assert_eq!(factorial(1.), Ok(1.));
+      assert_eq!(factorial(2.), Ok(2.));
+      assert_eq!(factorial(3.), Ok(6.));
+      assert_eq!(factorial(170.), Ok(7.257415615307994e306));
+      assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
+      
+      match factorial(1.1) {
+        Err(_) => {},
+        _ => panic!("Shouldn't be able to do factorial on number with fractional component!")
+      }
+
+      match factorial(-1.) {
+        Err(_) => {},
+        _ => panic!("Shouldn't be able to do factorial on negative number!")
+      }
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,9 +1,11 @@
-pub fn factorial(num: u64) -> u64 {
-	if num == 0 ||
-		num == 1 {
-		return 1;
+// Why the heck does factorial take a float?
+// This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
+pub fn factorial(num: f64) -> f64 {
+	if num == 0. ||
+		num == 1. {
+		return 1.;
 	} else {
-		return num * factorial(num - 1);
+		return num * factorial(num - 1.);
 	}
 }
 
@@ -13,10 +15,10 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0), 1);
-      assert_eq!(factorial(1), 1);
-      assert_eq!(factorial(2), 2);
-      assert_eq!(factorial(3), 6);
-      assert_eq!(factorial(4), 24);
+      assert_eq!(factorial(0.), 1.);
+      assert_eq!(factorial(1.), 1.);
+      assert_eq!(factorial(2.), 2.);
+      assert_eq!(factorial(3.), 6.);
+      assert_eq!(factorial(4.), 24.);
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,22 +1,21 @@
 // Why the heck does factorial take a float?
 // This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
 fn factorial_unsafe(num: f64) -> f64 {
-	if num == 0. ||
-		num == 1. {
-		return 1.;
-	} else {
-		return num * factorial_unsafe(num - 1.);
-	}
+    if num == 0. || num == 1. {
+        return 1.;
+    } else {
+        return num * factorial_unsafe(num - 1.);
+    }
 }
 
 pub fn factorial(num: f64) -> Result<f64, &'static str> {
-  if num.fract() != 0. || num < 0. {
-    return Err("Number must be non-negative with no fractional component!")
-  } else if num > 170. {
-    return Ok(std::f64::INFINITY)
-  } else {
-    return Ok(factorial_unsafe(num))
-  }
+    if num.fract() != 0. || num < 0. {
+        return Err("Number must be non-negative with no fractional component!");
+    } else if num > 170. {
+        return Ok(std::f64::INFINITY);
+    } else {
+        return Ok(factorial_unsafe(num));
+    }
 }
 
 #[cfg(test)]
@@ -25,21 +24,21 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0.), Ok(1.));
-      assert_eq!(factorial(1.), Ok(1.));
-      assert_eq!(factorial(2.), Ok(2.));
-      assert_eq!(factorial(3.), Ok(6.));
-      assert_eq!(factorial(170.), Ok(7.257415615307994e306));
-      assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
-      
-      match factorial(1.1) {
-        Err(_) => {},
-        _ => panic!("Shouldn't be able to do factorial on number with fractional component!")
-      }
+        assert_eq!(factorial(0.), Ok(1.));
+        assert_eq!(factorial(1.), Ok(1.));
+        assert_eq!(factorial(2.), Ok(2.));
+        assert_eq!(factorial(3.), Ok(6.));
+        assert_eq!(factorial(170.), Ok(7.257415615307994e306));
+        assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
 
-      match factorial(-1.) {
-        Err(_) => {},
-        _ => panic!("Shouldn't be able to do factorial on negative number!")
-      }
+        match factorial(1.1) {
+            Err(_) => {}
+            _ => panic!("Shouldn't be able to do factorial on number with fractional component!"),
+        }
+
+        match factorial(-1.) {
+            Err(_) => {}
+            _ => panic!("Shouldn't be able to do factorial on negative number!"),
+        }
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,0 +1,22 @@
+pub fn factorial(num: u64) -> u64 {
+	if num == 0 ||
+		num == 1 {
+		return 1;
+	} else {
+		return num * factorial(num - 1);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_factorial() {
+      assert_eq!(factorial(0), 1);
+      assert_eq!(factorial(1), 1);
+      assert_eq!(factorial(2), 2);
+      assert_eq!(factorial(3), 6);
+      assert_eq!(factorial(4), 24);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ extern crate serde_test;
 use std::fmt;
 
 mod expr;
+mod extra_math;
 pub mod shunting_yard;
 pub mod tokenizer;
 
@@ -218,6 +219,8 @@ pub enum Error {
     ParseError(ParseError),
     /// The shunting-yard algorithm returned an error.
     RPNError(RPNError),
+    // A catch all for all other errors during evaluation
+    EvalError(String),
 }
 
 impl fmt::Display for Error {
@@ -235,6 +238,10 @@ impl fmt::Display for Error {
             }
             Error::RPNError(ref e) => {
                 try!(write!(f, "RPN error: "));
+                e.fmt(f)
+            }
+            Error::EvalError(ref e) => {
+                try!(write!(f, "Eval error: "));
                 e.fmt(f)
             }
         }
@@ -258,8 +265,9 @@ impl std::error::Error for Error {
         match *self {
             Error::UnknownVariable(_) => "unknown variable",
             Error::Function(_, _) => "function evaluation error",
+             Error::EvalError(_) => "eval error",
             Error::ParseError(ref e) => e.description(),
-            Error::RPNError(ref e) => e.description(),
+            Error::RPNError(ref e) => e.description()
         }
     }
 
@@ -268,7 +276,7 @@ impl std::error::Error for Error {
             Error::ParseError(ref e) => Some(e),
             Error::RPNError(ref e) => Some(e),
             Error::Function(_, ref e) => Some(e),
-            _ => None,
+            _ => None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,9 @@ impl std::error::Error for Error {
         match *self {
             Error::UnknownVariable(_) => "unknown variable",
             Error::Function(_, _) => "function evaluation error",
-             Error::EvalError(_) => "eval error",
+            Error::EvalError(_) => "eval error",
             Error::ParseError(ref e) => e.description(),
-            Error::RPNError(ref e) => e.description()
+            Error::RPNError(ref e) => e.description(),
         }
     }
 
@@ -276,7 +276,7 @@ impl std::error::Error for Error {
             Error::ParseError(ref e) => Some(e),
             Error::RPNError(ref e) => Some(e),
             Error::Function(_, ref e) => Some(e),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -214,8 +214,26 @@ mod tests {
             Ok(vec![Number(1.), Unary(Fact), Number(2.), Binary(Pow)])
         );
         assert_eq!(
-            to_rpn(&[Number(1.), Binary(Times), Number(2.), Unary(Fact)]),
-            Ok(vec![Number(1.), Number(2.), Unary(Fact), Binary(Times)])
+            to_rpn(&[
+                Number(1.), 
+                Unary(Fact), 
+                Binary(Div), 
+                LParen, 
+                Number(2.), 
+                Binary(Plus), 
+                Number(3.), 
+                RParen, 
+                Unary(Fact)
+            ]),
+            Ok(vec![
+                Number(1.), 
+                Unary(Fact), 
+                Number(2.), 
+                Number(3.), 
+                Binary(Plus), 
+                Unary(Fact), 
+                Binary(Div)
+            ])
         );
         assert_eq!(
             to_rpn(&[

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -215,23 +215,23 @@ mod tests {
         );
         assert_eq!(
             to_rpn(&[
-                Number(1.), 
-                Unary(Fact), 
-                Binary(Div), 
-                LParen, 
-                Number(2.), 
-                Binary(Plus), 
-                Number(3.), 
-                RParen, 
+                Number(1.),
+                Unary(Fact),
+                Binary(Div),
+                LParen,
+                Number(2.),
+                Binary(Plus),
+                Number(3.),
+                RParen,
                 Unary(Fact)
             ]),
             Ok(vec![
-                Number(1.), 
-                Unary(Fact), 
-                Number(2.), 
-                Number(3.), 
-                Binary(Plus), 
-                Unary(Fact), 
+                Number(1.),
+                Unary(Fact),
+                Number(2.),
+                Number(3.),
+                Binary(Plus),
+                Unary(Fact),
                 Binary(Div)
             ])
         );

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -72,9 +72,11 @@ fn prec_assoc(token: &Token) -> (u32, Associativity) {
             Plus | Minus => (1, Left),
             Times | Div | Rem => (2, Left),
             Pow => (4, Right),
+            _ => unimplemented!(),
         },
         Unary(op) => match op {
             Plus | Minus => (3, NA),
+            Fact => (5, NA),
             _ => unimplemented!(),
         },
         Var(_) | Number(_) | Func(..) | LParen | RParen | Comma => (0, NA),
@@ -206,6 +208,14 @@ mod tests {
         assert_eq!(
             to_rpn(&[Unary(Minus), Number(1.), Binary(Pow), Number(2.)]),
             Ok(vec![Number(1.), Number(2.), Binary(Pow), Unary(Minus)])
+        );
+        assert_eq!(
+            to_rpn(&[Number(1.), Unary(Fact), Binary(Pow), Number(2.)]),
+            Ok(vec![Number(1.), Unary(Fact), Number(2.), Binary(Pow)])
+        );
+        assert_eq!(
+            to_rpn(&[Number(1.), Binary(Times), Number(2.), Unary(Fact)]),
+            Ok(vec![Number(1.), Number(2.), Unary(Fact), Binary(Times)])
         );
         assert_eq!(
             to_rpn(&[

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -57,7 +57,7 @@ pub enum Operation {
     Div,
     Rem,
     Pow,
-    Fact
+    Fact,
 }
 
 /// Expression tokens.
@@ -103,7 +103,10 @@ named!(
     )
 );
 
-named!(fact<Token>, chain!(tag!("!"), || Token::Unary(Operation::Fact)));
+named!(
+    fact<Token>,
+    chain!(tag!("!"), || Token::Unary(Operation::Fact))
+);
 named!(lparen<Token>, chain!(tag!("("), || Token::LParen));
 named!(rparen<Token>, chain!(tag!(")"), || Token::RParen));
 named!(comma<Token>, chain!(tag!(","), || Token::Comma));
@@ -125,7 +128,8 @@ fn ident(input: &[u8]) -> IResult<&[u8], &[u8]> {
                 .take_while(|&&c| match c {
                     b'a'...b'z' | b'A'...b'Z' | b'_' | b'0'...b'9' => true,
                     _ => false,
-                }).count();
+                })
+                .count();
             let (parsed, rest) = input.split_at(n + 1);
             Done(rest, parsed)
         }
@@ -234,7 +238,11 @@ named!(
 );
 named!(
     after_rexpr<Token>,
-    delimited!(opt!(multispace), alt!(fact | binop | rparen), opt!(multispace))
+    delimited!(
+        opt!(multispace),
+        alt!(fact | binop | rparen),
+        opt!(multispace)
+    )
 );
 named!(
     after_rexpr_no_paren<Token>,
@@ -505,7 +513,14 @@ mod tests {
 
         assert_eq!(
             tokenize("1 + 3! + 1"),
-            Ok(vec![Number(1f64), Binary(Plus), Number(3f64), Unary(Fact), Binary(Plus), Number(1f64)])
+            Ok(vec![
+                Number(1f64),
+                Binary(Plus),
+                Number(3f64),
+                Unary(Fact),
+                Binary(Plus),
+                Number(1f64)
+            ])
         );
 
         assert_eq!(tokenize("!3"), Err(ParseError::UnexpectedToken(0)));


### PR DESCRIPTION
Add support for the `!` (factorial) Unary operator, as well as add the `log10(x)` function.

Also, replace the `panic!`s during evaluation with a new general error, `Error::EvalError` allowing the client to catch the error rather than forcing things to blow up.