### PR TITLE
removed depracation warnings and substituted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 - `bind` and `bind_with_context` functions return unboxed closures
   (requires Rust 1.26).
 
+- [#17](https://github.com/rekka/meval-rs/pull/17)
+
+    - Implement `bind4`, `bind4_with_context`, `bind5`,
+      `bind5_with_context` and `bindn`.
+
+    - Bugfix: Serialization from JSON now works as expected.
+
+- Drop support for serialization from non-self-describing formats.
+
 # 0.1.1
 
 - Implement `Default` for `Context`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.1
+
+- Implement `Default` for `Context`
+
+# 0.1.0
+
+- Support `serde-1.0.0`
+
 # 0.0.9
 
 - Bug #13: failed build with `serde` feature disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- `bind` and `bind_with_context` functions return unboxed closures
+  (requires Rust 1.26).
+
 # 0.1.1
 
 - Implement `Default` for `Context`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.2
 
 - `bind` and `bind_with_context` functions return unboxed closures
   (requires Rust 1.26).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", optional = true }
 gnuplot = "0.0.23"
 serde_test = "1"
 serde_derive = "1"
+serde_json = "1"
 toml = "0.4.5"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Unlicense/MIT"
 name = "meval"
 readme = "README.md"
 repository = "https://github.com/rekka/meval-rs"
-version = "0.1.0"
+version = "0.1.1"
 exclude = ["README.tpl", ".travis.yml"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Unlicense/MIT"
 name = "meval"
 readme = "README.md"
 repository = "https://github.com/rekka/meval-rs"
-version = "0.1.1"
+version = "0.2.0"
 exclude = ["README.tpl", ".travis.yml"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simply add the corresponding entry to your `Cargo.toml` dependency list:
 
 ```toml
 [dependencies]
-meval = "0.1"
+meval = "0.2"
 ```
 
 and add this to your crate root:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 [![](http://meritbadge.herokuapp.com/meval)](https://crates.io/crates/meval)
 [![meval at docs.rs](https://docs.rs/meval/badge.svg)](https://docs.rs/meval)
 
-[Expr]: https://docs.rs/meval/0.1.0/meval/struct.Expr.html
-[Expr::bind]: https://docs.rs/meval/0.1.0/meval/struct.Expr.html#method.bind
-[Context]: https://docs.rs/meval/0.1.0/meval/trait.Context.html
-
 # meval
 
 This [Rust] crate provides a simple math expression parsing and evaluation. Its main goal is to
@@ -44,7 +40,7 @@ fn main() {
 }
 ```
 
-Need to define a Rust function from an expression? No problem, use [`Expr`][Expr]
+Need to define a Rust function from an expression? No problem, use `Expr`
 for this and more:
 
 ```rust
@@ -60,7 +56,7 @@ fn main() {
 }
 ```
 
-[`Expr::bind`][Expr::bind] returns a boxed closure that is slightly less
+`Expr::bind` returns a boxed closure that is slightly less
 convenient than an unboxed closure since `Box<Fn(f64) -> f64>` does not implement `FnOnce`,
 `Fn` or `FnMut`. So to use it directly as a function argument where a closure is expected, it
 has to be manually dereferenced:
@@ -70,7 +66,7 @@ let func = "x".parse::<meval::Expr>().unwrap().bind("x").unwrap();
 let r = Some(2.).map(&*func);
 ```
 
-Custom constants and functions? Define a [`Context`][Context]!
+Custom constants and functions? Define a `Context`!
 
 ```rust
 use meval::{Expr, Context};
@@ -89,7 +85,7 @@ assert_eq!(func(2.), -2. * -1. + 2. + 1.);
 
 For functions of 2, 3, and N variables use `Context::func2`, `Context::func3` and
 `Context::funcn`,
-respectively. See [`Context`][Context] for more options.
+respectively. See `Context` for more options.
 
 If you need a custom function depending on mutable parameters, you will need to use a
 [`Cell`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html):
@@ -143,7 +139,7 @@ supported:
 
 ## Deserialization
 
-[`Expr`][Expr] supports deserialization using the [serde] library to make flexible
+`Expr` supports deserialization using the [serde] library to make flexible
 configuration easy to set up, if the feature `serde` is enabled
 (disabled by default).
 
@@ -191,9 +187,6 @@ number_ "converter". For more advanced scripting, see:
 [Rust]: https://www.rust-lang.org/
 [std-float]: http://doc.rust-lang.org/stable/std/primitive.f64.html
 
-[Expr]: struct.Expr.html
-[Expr::bind]: struct.Expr.html#method.bind
-[Context]: struct.Context.html
 [serde]: https://crates.io/crates/serde
 [dyon]: https://crates.io/crates/dyon
 [gluon]: https://crates.io/crates/gluon

--- a/README.md
+++ b/README.md
@@ -170,8 +170,10 @@ fn main() {
 
 This is a toy project of mine for learning Rust, and to be hopefully useful when writing
 command line scripts. There is no plan to make this anything more than _math expression ->
-number_ "converter". For more advanced scripting, see:
+number_ "converter". For more advanced uses, see:
 
+- [evalexpr] -- A more complete expression evaluator that supports value
+  types, boolean operators, strings, assignment operators, ...
 - [dyon] -- A rusty dynamically typed scripting language
 - [gluon] -- A static, type inferred programming language for application embedding
 - [rodolf0/tox](https://github.com/rodolf0/tox) -- another shunting yard expression parser
@@ -180,6 +182,7 @@ number_ "converter". For more advanced scripting, see:
 [std-float]: http://doc.rust-lang.org/stable/std/primitive.f64.html
 
 [serde]: https://crates.io/crates/serde
+[evalexpr]: https://crates.io/crates/evalexpr
 [dyon]: https://crates.io/crates/dyon
 [gluon]: https://crates.io/crates/gluon
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ assert_eq!(func(2.), 5.);
 `meval` supports basic mathematical operations on floating point numbers:
 
 - binary operators: `+`, `-`, `*`, `/`, `%` (remainder), `^` (power)
-- unary operators: `+`, `-`
+- unary operators: `+`, `-`, `!` (factorial)
 
 It supports custom variables and functions like `x`, `weight`, `C_0`, `f(1)`, etc. A variable
 or function name must start with `[a-zA-Z_]` and can contain only `[a-zA-Z0-9_]`. Custom

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ and add this to your crate root:
 extern crate meval;
 ```
 
+**Requires Rust 1.26.**
+
 ## Simple examples
 
 ```rust
@@ -54,16 +56,6 @@ fn main() {
 
     println!("sin(pi * x), 0 <= x <= 1: {:?}", vs);
 }
-```
-
-`Expr::bind` returns a boxed closure that is slightly less
-convenient than an unboxed closure since `Box<Fn(f64) -> f64>` does not implement `FnOnce`,
-`Fn` or `FnMut`. So to use it directly as a function argument where a closure is expected, it
-has to be manually dereferenced:
-
-```rust
-let func = "x".parse::<meval::Expr>().unwrap().bind("x").unwrap();
-let r = Some(2.).map(&*func);
 ```
 
 Custom constants and functions? Define a `Context`!

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ supported:
 - functions implemented using functions of the same name in [Rust std library][std-float]:
 
     - `sqrt`, `abs`
-    - `exp`, `ln`
+    - `exp`, `ln`, `log10`
     - `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`
     - `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`
     - `floor`, `ceil`, `round`

--- a/README.md
+++ b/README.md
@@ -22,19 +22,11 @@ Simply add the corresponding entry to your `Cargo.toml` dependency list:
 meval = "0.2"
 ```
 
-and add this to your crate root:
-
-```rust
-extern crate meval;
-```
-
 **Requires Rust 1.26.**
 
 ## Simple examples
 
 ```rust
-extern crate meval;
-
 fn main() {
     let r = meval::eval_str("1 + 2").unwrap();
 
@@ -46,8 +38,6 @@ Need to define a Rust function from an expression? No problem, use `Expr`
 for this and more:
 
 ```rust
-extern crate meval;
-
 fn main() {
     let expr: meval::Expr = "sin(pi * x)".parse().unwrap();
     let func = expr.bind("x").unwrap();

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![](http://meritbadge.herokuapp.com/meval)](https://crates.io/crates/meval)
 [![meval at docs.rs](https://docs.rs/meval/badge.svg)](https://docs.rs/meval)
 
-[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
-[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
-[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html
+[Expr]: https://docs.rs/meval/0.1.0/meval/struct.Expr.html
+[Expr::bind]: https://docs.rs/meval/0.1.0/meval/struct.Expr.html#method.bind
+[Context]: https://docs.rs/meval/0.1.0/meval/trait.Context.html
 
 # meval
 
@@ -15,9 +15,7 @@ Rust, think initial data and boundary conditions, via config files or command li
 
 ## Documentation
 
-- [Full API documentation (crates.io)](https://docs.rs/meval)
-
-- [Full API documentation (master)](http://rekka.github.io/meval-rs/meval/index.html)
+- [Full API documentation](https://docs.rs/meval)
 
 ## Installation
 
@@ -205,7 +203,3 @@ number_ "converter". For more advanced scripting, see:
 This project is dual-licensed under the Unlicense and MIT licenses.
 
 You may use this code under the terms of either license.
-
-[Expr]: http://rekka.github.io/meval-rs/meval/struct.Expr.html
-[Expr::bind]: http://rekka.github.io/meval-rs/meval/struct.Expr.html#method.bind
-[Context]: http://rekka.github.io/meval-rs/meval/trait.Context.html

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,7 +12,7 @@ use meval::max_array;
 use meval::ContextProvider;
 use std::f64::consts;
 
-const EXPR: &'static str = "abs(sin(x + 1) * (x^2 + x + 1))";
+const EXPR: &str = "abs(sin(x + 1) * (x^2 + x + 1))";
 
 #[bench]
 fn parsing(b: &mut Bencher) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,16 +1,16 @@
 #![feature(test)]
 
-extern crate test;
 extern crate meval;
+extern crate test;
 
-use test::Bencher;
-use meval::Expr;
-use meval::Context;
-use meval::FuncEvalError;
-use meval::min_array;
 use meval::max_array;
+use meval::min_array;
+use meval::Context;
 use meval::ContextProvider;
+use meval::Expr;
+use meval::FuncEvalError;
 use std::f64::consts;
+use test::Bencher;
 
 const EXPR: &str = "abs(sin(x + 1) * (x^2 + x + 1))";
 
@@ -42,9 +42,7 @@ fn evaluation_hashcontext(b: &mut Bencher) {
 #[bench]
 fn default_context(b: &mut Bencher) {
     let expr: Expr = "1 + 2 * 3".parse().unwrap();
-    b.iter(|| {
-        expr.eval()
-    });
+    b.iter(|| expr.eval());
 }
 
 macro_rules! one_arg {
@@ -54,7 +52,7 @@ macro_rules! one_arg {
         } else {
             Err(FuncEvalError::NumberArgs(1))
         }
-    }
+    };
 }
 
 macro_rules! two_args {
@@ -64,7 +62,7 @@ macro_rules! two_args {
         } else {
             Err(FuncEvalError::NumberArgs(2))
         }
-    }
+    };
 }
 
 macro_rules! one_or_more_arg {
@@ -74,7 +72,7 @@ macro_rules! one_or_more_arg {
         } else {
             Err(FuncEvalError::TooFewArguments)
         }
-    }
+    };
 }
 
 /// Built-in functions and constants.

--- a/examples/eval.rs
+++ b/examples/eval.rs
@@ -3,7 +3,7 @@ extern crate meval;
 use std::env::args;
 use meval::eval_str;
 
-const USAGE: &'static str = r"Simple math expression evaluation.
+const USAGE: &str = r"Simple math expression evaluation.
 
 Usage: eval EXPR1 EXPR2 ...";
 

--- a/examples/eval.rs
+++ b/examples/eval.rs
@@ -1,7 +1,7 @@
 extern crate meval;
 
-use std::env::args;
 use meval::eval_str;
+use std::env::args;
 
 const USAGE: &str = r"Simple math expression evaluation.
 

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -1,9 +1,9 @@
-extern crate meval;
 extern crate gnuplot;
+extern crate meval;
 
-use std::env::args;
-use gnuplot::{Figure, Caption};
+use gnuplot::{Caption, Figure};
 use meval::Expr;
+use std::env::args;
 
 const USAGE: &str = r"Plot functions of variable `x`.
 
@@ -40,7 +40,11 @@ fn main() {
                 }
             };
 
-            axes.lines(&xi, xi.iter().map(|&x| func(x)), &[Caption("plot" /* &arg */)]);
+            axes.lines(
+                &xi,
+                xi.iter().map(|&x| func(x)),
+                &[Caption("plot" /* &arg */)],
+            );
         }
     }
     fg.show();

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -36,7 +36,7 @@ fn main() {
             let func = match expr.bind("x") {
                 Ok(func) => func,
                 Err(e) => {
-                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e)
+                    return println!("Error when trying to bind variable `x` in {}: {}", arg, e);
                 }
             };
 

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -5,7 +5,7 @@ use std::env::args;
 use gnuplot::{Figure, Caption};
 use meval::Expr;
 
-const USAGE: &'static str = r"Plot functions of variable `x`.
+const USAGE: &str = r"Plot functions of variable `x`.
 
 Usage: plot EXPR1 EXPR2 ...
 
@@ -21,7 +21,7 @@ fn main() {
     fg.clear_axes();
 
     {
-        let mut axes = fg.axes2d();
+        let axes = fg.axes2d();
 
         let n = 100;
         let xi: Vec<_> = (0..n + 1).map(|i| i as f64 / n as f64).collect();

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,8 @@
 //! Deserialization utilities.
+use super::Expr;
 use serde::de;
 use serde::de::Error;
 use serde::Deserialize;
-use super::Expr;
 
 /// Deserialize into [`Expr`](../struct.Expr.html) and then evaluate using `Expr::eval`.
 ///
@@ -32,5 +32,7 @@ use super::Expr;
 ///
 /// See [crate root](../index.html#deserialization) for another example.
 pub fn as_f64<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<f64, D::Error> {
-    Expr::deserialize(deserializer)?.eval().map_err(D::Error::custom)
+    Expr::deserialize(deserializer)?
+        .eval()
+        .map_err(D::Error::custom)
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -156,7 +156,7 @@ impl Expr {
     where
         C: ContextProvider + 'a,
     {
-        try!(self.check_context(((var, 0.), &ctx)));
+        self.check_context(((var, 0.), &ctx))?;
         let var = var.to_owned();
         Ok(move |x| {
             self.eval_with_context(((&var, x), &ctx))
@@ -194,7 +194,7 @@ impl Expr {
     where
         C: ContextProvider + 'a,
     {
-        try!(self.check_context(([(var1, 0.), (var2, 0.)], &ctx)));
+        self.check_context(([(var1, 0.), (var2, 0.)], &ctx))?;
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
         Ok(move |x, y| {
@@ -239,7 +239,7 @@ impl Expr {
     where
         C: ContextProvider + 'a,
     {
-        try!(self.check_context(([(var1, 0.), (var2, 0.), (var3, 0.)], &ctx)));
+        self.check_context(([(var1, 0.), (var2, 0.), (var3, 0.)], &ctx))?;
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
         let var3 = var3.to_owned();
@@ -287,7 +287,7 @@ impl Expr {
     where
         C: ContextProvider + 'a,
     {
-        try!(self.check_context(([(var1, 0.), (var2, 0.), (var3, 0.), (var4, 0.)], &ctx)));
+        self.check_context(([(var1, 0.), (var2, 0.), (var3, 0.), (var4, 0.)], &ctx))?;
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
         let var3 = var3.to_owned();
@@ -338,10 +338,10 @@ impl Expr {
     where
         C: ContextProvider + 'a,
     {
-        try!(self.check_context((
+        self.check_context((
             [(var1, 0.), (var2, 0.), (var3, 0.), (var4, 0.), (var5, 0.)],
             &ctx
-        )));
+        ))?;
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
         let var3 = var3.to_owned();
@@ -389,12 +389,12 @@ impl Expr {
         C: ContextProvider + 'a,
     {
         let n = vars.len();
-        try!(self.check_context((
+        self.check_context((
             vars.into_iter()
                 .zip(vec![0.; n].into_iter())
                 .collect::<Vec<_>>(),
             &ctx
-        )));
+        ))?;
         let vars = vars.iter().map(|v| v.to_owned()).collect::<Vec<_>>();
         Ok(move |x: &[f64]| {
             self.eval_with_context((
@@ -447,7 +447,7 @@ impl Expr {
 
 /// Evaluates a string with built-in constants and functions.
 pub fn eval_str<S: AsRef<str>>(expr: S) -> Result<f64, Error> {
-    let expr = try!(Expr::from_str(expr.as_ref()));
+    let expr = Expr::from_str(expr.as_ref())?;
 
     expr.eval_with_context(builtin())
 }
@@ -456,9 +456,9 @@ impl FromStr for Expr {
     type Err = Error;
     /// Constructs an expression by parsing a string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tokens = try!(tokenize(s));
+        let tokens = tokenize(s)?;
 
-        let rpn = try!(to_rpn(&tokens));
+        let rpn = to_rpn(&tokens)?;
 
         Ok(Expr { rpn: rpn })
     }
@@ -471,7 +471,7 @@ pub fn eval_str_with_context<S: AsRef<str>, C: ContextProvider>(
     expr: S,
     ctx: C,
 ) -> Result<f64, Error> {
-    let expr = try!(Expr::from_str(expr.as_ref()));
+    let expr = Expr::from_str(expr.as_ref())?;
 
     expr.eval_with_context(ctx)
 }
@@ -856,7 +856,7 @@ impl<'a> Default for Context<'a> {
     }
 }
 
-type GuardedFunc<'a> = Rc<Fn(&[f64]) -> Result<f64, FuncEvalError> + 'a>;
+type GuardedFunc<'a> = Rc<dyn Fn(&[f64]) -> Result<f64, FuncEvalError> + 'a>;
 
 /// Trait for types that can specify the number of required arguments for a function with a
 /// variable number of arguments.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -6,11 +6,11 @@ use std::str::FromStr;
 
 type ContextHashMap<K, V> = FnvHashMap<K, V>;
 
+use extra_math::factorial;
 use shunting_yard::to_rpn;
 use std;
 use std::fmt;
 use tokenizer::{tokenize, Token};
-use extra_math::factorial;
 use Error;
 
 /// Representation of a parsed expression.
@@ -66,7 +66,12 @@ impl Expr {
                         Div => left / right,
                         Rem => left % right,
                         Pow => left.powf(right),
-                        _ => return Err(Error::EvalError(format!("Unimplemented binary operation: {:?}", op))),
+                        _ => {
+                            return Err(Error::EvalError(format!(
+                                "Unimplemented binary operation: {:?}",
+                                op
+                            )));
+                        }
                     };
                     stack.push(r);
                 }
@@ -79,10 +84,15 @@ impl Expr {
                             // Check to make sure x has no fractional component (can be converted to int without loss)
                             match factorial(x) {
                                 Ok(res) => res,
-                                Err(e) => return Err(Error::EvalError(String::from(e)))
+                                Err(e) => return Err(Error::EvalError(String::from(e))),
                             }
                         }
-                        _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
+                        _ => {
+                            return Err(Error::EvalError(format!(
+                                "Unimplemented unary operation: {:?}",
+                                op
+                            )));
+                        }
                     };
                     stack.push(r);
                 }
@@ -92,7 +102,7 @@ impl Expr {
                             "eval: stack does not have enough arguments for function token \
                              {:?}",
                             token
-                        )))
+                        )));
                     }
                     match ctx.eval_func(n, &stack[stack.len() - i..]) {
                         Ok(r) => {
@@ -109,7 +119,10 @@ impl Expr {
 
         let r = stack.pop().expect("Stack is empty, this is impossible.");
         if !stack.is_empty() {
-            return Err(Error::EvalError(format!("There are still {} items on the stack.", stack.len())))
+            return Err(Error::EvalError(format!(
+                "There are still {} items on the stack.",
+                stack.len()
+            )));
         }
         Ok(r)
     }
@@ -344,7 +357,8 @@ impl Expr {
                     (&var5, x5),
                 ],
                 &ctx,
-            )).expect("Expr::bind5")
+            ))
+            .expect("Expr::bind5")
         })
     }
 
@@ -375,14 +389,12 @@ impl Expr {
         C: ContextProvider + 'a,
     {
         let n = vars.len();
-        try!(
-            self.check_context((
-                vars.into_iter()
-                    .zip(vec![0.; n].into_iter())
-                    .collect::<Vec<_>>(),
-                &ctx
-            ))
-        );
+        try!(self.check_context((
+            vars.into_iter()
+                .zip(vec![0.; n].into_iter())
+                .collect::<Vec<_>>(),
+            &ctx
+        )));
         let vars = vars.iter().map(|v| v.to_owned()).collect::<Vec<_>>();
         Ok(move |x: &[f64]| {
             self.eval_with_context((
@@ -391,7 +403,8 @@ impl Expr {
                     .map(|(v, x)| (v, *x))
                     .collect::<Vec<_>>(),
                 &ctx,
-            )).expect("Expr::bindn")
+            ))
+            .expect("Expr::bindn")
         })
     }
 
@@ -415,7 +428,10 @@ impl Expr {
                     }
                 }
                 Token::Func(_, None) => {
-                    return Err(Error::EvalError(format!("expr::check_context: Unexpected token: {:?}", *t)))
+                    return Err(Error::EvalError(format!(
+                        "expr::check_context: Unexpected token: {:?}",
+                        *t
+                    )));
                 }
                 Token::LParen
                 | Token::RParen
@@ -1069,7 +1085,7 @@ mod tests {
         assert_eq!(eval_str("10 % 9"), Ok(10f64 % 9f64));
 
         match eval_str("0.5!") {
-            Err(Error::EvalError(_)) => {},
+            Err(Error::EvalError(_)) => {}
             _ => panic!("Cannot evaluate factorial of non-integer"),
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -973,7 +973,7 @@ pub mod de {
                 }
             }
 
-            deserializer.deserialize_f64(ExprVisitor)
+            deserializer.deserialize_any(ExprVisitor)
         }
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -116,7 +116,7 @@ impl Expr {
     /// Returns `Err` if there is a variable in the expression that is not provided by the default
     /// context or `var`.
     pub fn bind<'a>(self, var: &str) -> Result<Box<Fn(f64) -> f64 + 'a>, Error> {
-        return self.bind_with_context(builtin(), var);
+        self.bind_with_context(builtin(), var)
     }
 
     /// Creates a function of one variable based on this expression.
@@ -135,7 +135,7 @@ impl Expr {
     {
         try!(self.check_context(((var, 0.), &ctx)));
         let var = var.to_owned();
-        return Ok(Box::new(move |x| self.eval_with_context(((&var, x), &ctx)).expect("Expr::bind")));
+        Ok(Box::new(move |x| self.eval_with_context(((&var, x), &ctx)).expect("Expr::bind")))
     }
 
     /// Creates a function of two variables based on this expression, with default constants and
@@ -148,7 +148,7 @@ impl Expr {
     /// Returns `Err` if there is a variable in the expression that is not provided by the default
     /// context or `var`.
     pub fn bind2<'a>(self, var1: &str, var2: &str) -> Result<Box<Fn(f64, f64) -> f64 + 'a>, Error> {
-        return self.bind2_with_context(builtin(), var1, var2);
+        self.bind2_with_context(builtin(), var1, var2)
     }
 
     /// Creates a function of two variables based on this expression.
@@ -169,9 +169,9 @@ impl Expr {
         try!(self.check_context(([(var1, 0.), (var2, 0.)], &ctx)));
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
-        return Ok(Box::new(move |x, y| {
+        Ok(Box::new(move |x, y| {
             self.eval_with_context(([(&var1, x), (&var2, y)], &ctx)).expect("Expr::bind2")
-        }));
+        }))
     }
 
     /// Creates a function of three variables based on this expression, with default constants and
@@ -188,7 +188,7 @@ impl Expr {
                      var2: &str,
                      var3: &str)
                      -> Result<Box<Fn(f64, f64, f64) -> f64 + 'a>, Error> {
-        return self.bind3_with_context(builtin(), var1, var2, var3);
+        self.bind3_with_context(builtin(), var1, var2, var3)
     }
 
     /// Creates a function of three variables based on this expression.
@@ -211,9 +211,9 @@ impl Expr {
         let var1 = var1.to_owned();
         let var2 = var2.to_owned();
         let var3 = var3.to_owned();
-        return Ok(Box::new(move |x, y, z| {
+        Ok(Box::new(move |x, y, z| {
             self.eval_with_context(([(&var1, x), (&var2, y), (&var3, z)], &ctx)).expect("Expr::bind3")
-        }));
+        }))
     }
 
     /// Checks that the value of every variable in the expression is specified by the context `ctx`.
@@ -222,7 +222,7 @@ impl Expr {
     ///
     /// Returns `Err` if a missing variable is detected.
     fn check_context<C: ContextProvider>(&self, ctx: C) -> Result<(), Error> {
-        for t in self.rpn.iter() {
+        for t in &self.rpn {
             match *t {
                 Token::Var(ref name) => {
                     if ctx.get_var(name).is_none() {
@@ -625,6 +625,12 @@ impl<'a> Context<'a> {
     {
         self.funcs.insert(name.into(), n_args.to_arg_guard(func));
         self
+    }
+}
+
+impl<'a> Default for Context<'a> {
+    fn default() -> Self {
+        Context::new()
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -79,10 +79,10 @@ impl Expr {
                             // Check to make sure x has no fractional component (can be converted to int without loss)
                             if x.fract() != 0. || x < 0. {
                                 return Err(Error::EvalError(format!("({})! cannot be evaluated. Must be a non-negative integer!", x)))
-                            } else if x > 20. {
+                            } else if x > 170. {
                                 std::f64::INFINITY
                             } else {
-                                factorial(x as u64) as f64
+                                factorial(x)
                             }
                         }
                         _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
@@ -1057,7 +1057,10 @@ mod tests {
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
         assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
-        assert_eq!(eval_str("25!"), Ok(std::f64::INFINITY));
+        assert_eq!(eval_str("170!"), Ok(7.257415615307994e306));
+        assert_eq!(eval_str("171!"), Ok(std::f64::INFINITY));
+        assert_eq!(eval_str("-171!"), Ok(std::f64::NEG_INFINITY));
+        assert_eq!(eval_str("150!/148!"), Ok(22350.));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -698,6 +698,7 @@ impl<'a> Context<'a> {
             ctx.func("sqrt", f64::sqrt);
             ctx.func("exp", f64::exp);
             ctx.func("ln", f64::ln);
+            ctx.func("log10", f64::log10);
             ctx.func("abs", f64::abs);
             ctx.func("sin", f64::sin);
             ctx.func("cos", f64::cos);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1057,6 +1057,7 @@ mod tests {
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
         assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
+        assert_eq!(eval_str("25!"), Ok(std::f64::INFINITY));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -10,6 +10,7 @@ use shunting_yard::to_rpn;
 use std;
 use std::fmt;
 use tokenizer::{tokenize, Token};
+use extra_math::factorial;
 use Error;
 
 /// Representation of a parsed expression.
@@ -65,24 +66,36 @@ impl Expr {
                         Div => left / right,
                         Rem => left % right,
                         Pow => left.powf(right),
+                        _ => panic!("Unimplemented binary operation: {:?}", op),
                     };
                     stack.push(r);
                 }
                 Unary(op) => {
                     let x = stack.pop().unwrap();
-                    match op {
-                        Plus => stack.push(x),
-                        Minus => stack.push(-x),
-                        _ => panic!("Unimplement unary operation: {:?}", op),
-                    }
+                    let r = match op {
+                        Plus => x,
+                        Minus => -x,
+                        Fact => {
+                            // Check to make sure x has no fractional component (can be converted to int without loss)
+                            if x.fract() != 0. || x < 0. {
+                                return Err(Error::EvalError(format!("({})! cannot be evaluated. Must be a non-negative integer!", x)))
+                            } else if x > 20. {
+                                std::f64::INFINITY
+                            } else {
+                                factorial(x as u64) as f64
+                            }
+                        }
+                        _ => return Err(Error::EvalError(format!("Unimplemented unary operation: {:?}", op))),
+                    };
+                    stack.push(r);
                 }
                 Func(ref n, Some(i)) => {
                     if stack.len() < i {
-                        panic!(
+                        return Err(Error::EvalError(format!(
                             "eval: stack does not have enough arguments for function token \
                              {:?}",
                             token
-                        );
+                        )))
                     }
                     match ctx.eval_func(n, &stack[stack.len() - i..]) {
                         Ok(r) => {
@@ -93,13 +106,13 @@ impl Expr {
                         Err(e) => return Err(Error::Function(n.to_owned(), e)),
                     }
                 }
-                _ => panic!("Unrecognized token: {:?}", token),
+                _ => return Err(Error::EvalError(format!("Unrecognized token: {:?}", token))),
             }
         }
 
         let r = stack.pop().expect("Stack is empty, this is impossible.");
         if !stack.is_empty() {
-            panic!("There are still {} items on the stack.", stack.len());
+            return Err(Error::EvalError(format!("There are still {} items on the stack.", stack.len())))
         }
         Ok(r)
     }
@@ -405,7 +418,7 @@ impl Expr {
                     }
                 }
                 Token::Func(_, None) => {
-                    panic!("expr::check_context: Unexpected token: {:?}", *t);
+                    return Err(Error::EvalError(format!("expr::check_context: Unexpected token: {:?}", *t)))
                 }
                 Token::LParen
                 | Token::RParen
@@ -1043,6 +1056,7 @@ mod tests {
         assert_eq!(eval_str("2 + 3"), Ok(5.));
         assert_eq!(eval_str("2 + (3 + 4)"), Ok(9.));
         assert_eq!(eval_str("-2^(4 - 3) * (3 + 4)"), Ok(-14.));
+        assert_eq!(eval_str("-2*3! + 1"), Ok(-11.));
         assert_eq!(eval_str("a + 3"), Err(Error::UnknownVariable("a".into())));
         assert_eq!(eval_str("round(sin (pi) * cos(0))"), Ok(0.));
         assert_eq!(eval_str("round( sqrt(3^2 + 4^2)) "), Ok(5.));
@@ -1054,6 +1068,16 @@ mod tests {
             Ok((1f64).sin() + (2f64).cos())
         );
         assert_eq!(eval_str("10 % 9"), Ok(10f64 % 9f64));
+
+        match eval_str("(-2)!") {
+            Err(Error::EvalError(_)) => {},
+            _ => panic!("Cannot evaluate factorial of -2"),
+        }
+
+        match eval_str("0.5!") {
+            Err(Error::EvalError(_)) => {},
+            _ => panic!("Cannot evaluate factorial of non-integer"),
+        }
     }
 
     #[test]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -765,7 +765,7 @@ pub mod de {
                 }
             }
 
-            deserializer.deserialize_str(ExprVisitor)
+            deserializer.deserialize_f64(ExprVisitor)
         }
     }
 

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,12 +1,22 @@
 // Why the heck does factorial take a float?
 // This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
-pub fn factorial(num: f64) -> f64 {
+fn factorial_unsafe(num: f64) -> f64 {
 	if num == 0. ||
 		num == 1. {
 		return 1.;
 	} else {
-		return num * factorial(num - 1.);
+		return num * factorial_unsafe(num - 1.);
 	}
+}
+
+pub fn factorial(num: f64) -> Result<f64, &'static str> {
+  if num.fract() != 0. || num < 0. {
+    return Err("Number must be non-negative with no fractional component!")
+  } else if num > 170. {
+    return Ok(std::f64::INFINITY)
+  } else {
+    return Ok(factorial_unsafe(num))
+  }
 }
 
 #[cfg(test)]
@@ -15,10 +25,21 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0.), 1.);
-      assert_eq!(factorial(1.), 1.);
-      assert_eq!(factorial(2.), 2.);
-      assert_eq!(factorial(3.), 6.);
-      assert_eq!(factorial(4.), 24.);
+      assert_eq!(factorial(0.), Ok(1.));
+      assert_eq!(factorial(1.), Ok(1.));
+      assert_eq!(factorial(2.), Ok(2.));
+      assert_eq!(factorial(3.), Ok(6.));
+      assert_eq!(factorial(170.), Ok(7.257415615307994e306));
+      assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
+      
+      match factorial(1.1) {
+        Err(_) => {},
+        _ => panic!("Shouldn't be able to do factorial on number with fractional component!")
+      }
+
+      match factorial(-1.) {
+        Err(_) => {},
+        _ => panic!("Shouldn't be able to do factorial on negative number!")
+      }
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,9 +1,11 @@
-pub fn factorial(num: u64) -> u64 {
-	if num == 0 ||
-		num == 1 {
-		return 1;
+// Why the heck does factorial take a float?
+// This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
+pub fn factorial(num: f64) -> f64 {
+	if num == 0. ||
+		num == 1. {
+		return 1.;
 	} else {
-		return num * factorial(num - 1);
+		return num * factorial(num - 1.);
 	}
 }
 
@@ -13,10 +15,10 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0), 1);
-      assert_eq!(factorial(1), 1);
-      assert_eq!(factorial(2), 2);
-      assert_eq!(factorial(3), 6);
-      assert_eq!(factorial(4), 24);
+      assert_eq!(factorial(0.), 1.);
+      assert_eq!(factorial(1.), 1.);
+      assert_eq!(factorial(2.), 2.);
+      assert_eq!(factorial(3.), 6.);
+      assert_eq!(factorial(4.), 24.);
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,22 +1,21 @@
 // Why the heck does factorial take a float?
 // This is to take advantage of the fact that std::f64::MAX >>> std::u64::MAX
 fn factorial_unsafe(num: f64) -> f64 {
-	if num == 0. ||
-		num == 1. {
-		return 1.;
-	} else {
-		return num * factorial_unsafe(num - 1.);
-	}
+    if num == 0. || num == 1. {
+        return 1.;
+    } else {
+        return num * factorial_unsafe(num - 1.);
+    }
 }
 
 pub fn factorial(num: f64) -> Result<f64, &'static str> {
-  if num.fract() != 0. || num < 0. {
-    return Err("Number must be non-negative with no fractional component!")
-  } else if num > 170. {
-    return Ok(std::f64::INFINITY)
-  } else {
-    return Ok(factorial_unsafe(num))
-  }
+    if num.fract() != 0. || num < 0. {
+        return Err("Number must be non-negative with no fractional component!");
+    } else if num > 170. {
+        return Ok(std::f64::INFINITY);
+    } else {
+        return Ok(factorial_unsafe(num));
+    }
 }
 
 #[cfg(test)]
@@ -25,21 +24,21 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-      assert_eq!(factorial(0.), Ok(1.));
-      assert_eq!(factorial(1.), Ok(1.));
-      assert_eq!(factorial(2.), Ok(2.));
-      assert_eq!(factorial(3.), Ok(6.));
-      assert_eq!(factorial(170.), Ok(7.257415615307994e306));
-      assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
-      
-      match factorial(1.1) {
-        Err(_) => {},
-        _ => panic!("Shouldn't be able to do factorial on number with fractional component!")
-      }
+        assert_eq!(factorial(0.), Ok(1.));
+        assert_eq!(factorial(1.), Ok(1.));
+        assert_eq!(factorial(2.), Ok(2.));
+        assert_eq!(factorial(3.), Ok(6.));
+        assert_eq!(factorial(170.), Ok(7.257415615307994e306));
+        assert_eq!(factorial(171.), Ok(std::f64::INFINITY));
 
-      match factorial(-1.) {
-        Err(_) => {},
-        _ => panic!("Shouldn't be able to do factorial on negative number!")
-      }
+        match factorial(1.1) {
+            Err(_) => {}
+            _ => panic!("Shouldn't be able to do factorial on number with fractional component!"),
+        }
+
+        match factorial(-1.) {
+            Err(_) => {}
+            _ => panic!("Shouldn't be able to do factorial on negative number!"),
+        }
     }
 }

--- a/src/extra_math.rs
+++ b/src/extra_math.rs
@@ -1,0 +1,22 @@
+pub fn factorial(num: u64) -> u64 {
+	if num == 0 ||
+		num == 1 {
+		return 1;
+	} else {
+		return num * factorial(num - 1);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_factorial() {
+      assert_eq!(factorial(0), 1);
+      assert_eq!(factorial(1), 1);
+      assert_eq!(factorial(2), 2);
+      assert_eq!(factorial(3), 6);
+      assert_eq!(factorial(4), 24);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //! extern crate meval;
 //! ```
 //!
+//!  **Requires Rust 1.26.**
+//!
 //! # Simple examples
 //!
 //! ```rust
@@ -48,16 +50,6 @@
 //!
 //!     println!("sin(pi * x), 0 <= x <= 1: {:?}", vs);
 //! }
-//! ```
-//!
-//! [`Expr::bind`][Expr::bind] returns a boxed closure that is slightly less
-//! convenient than an unboxed closure since `Box<Fn(f64) -> f64>` does not implement `FnOnce`,
-//! `Fn` or `FnMut`. So to use it directly as a function argument where a closure is expected, it
-//! has to be manually dereferenced:
-//!
-//! ```rust
-//! let func = "x".parse::<meval::Expr>().unwrap().bind("x").unwrap();
-//! let r = Some(2.).map(&*func);
 //! ```
 //!
 //! Custom constants and functions? Define a [`Context`][Context]!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,9 @@ extern crate serde_test;
 
 use std::fmt;
 
-pub mod tokenizer;
-pub mod shunting_yard;
 mod expr;
+pub mod shunting_yard;
+pub mod tokenizer;
 
 #[cfg(feature = "serde")]
 pub mod de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ extern crate serde_test;
 use std::fmt;
 
 mod expr;
+mod extra_math;
 pub mod shunting_yard;
 pub mod tokenizer;
 
@@ -218,6 +219,8 @@ pub enum Error {
     ParseError(ParseError),
     /// The shunting-yard algorithm returned an error.
     RPNError(RPNError),
+    // A catch all for all other errors during evaluation
+    EvalError(String),
 }
 
 impl fmt::Display for Error {
@@ -235,6 +238,10 @@ impl fmt::Display for Error {
             }
             Error::RPNError(ref e) => {
                 try!(write!(f, "RPN error: "));
+                e.fmt(f)
+            }
+            Error::EvalError(ref e) => {
+                try!(write!(f, "Eval error: "));
                 e.fmt(f)
             }
         }
@@ -258,8 +265,9 @@ impl std::error::Error for Error {
         match *self {
             Error::UnknownVariable(_) => "unknown variable",
             Error::Function(_, _) => "function evaluation error",
+             Error::EvalError(_) => "eval error",
             Error::ParseError(ref e) => e.description(),
-            Error::RPNError(ref e) => e.description(),
+            Error::RPNError(ref e) => e.description()
         }
     }
 
@@ -268,7 +276,7 @@ impl std::error::Error for Error {
             Error::ParseError(ref e) => Some(e),
             Error::RPNError(ref e) => Some(e),
             Error::Function(_, ref e) => Some(e),
-            _ => None,
+            _ => None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! meval = "0.1"
+//! meval = "0.2"
 //! ```
 //!
 //! and add this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@
 //!     #[serde(deserialize_with = "meval::de::as_f64")]
 //!     t0: f64,
 //!     f: Expr,
+//!     g: Expr,
 //! }
 //!
 //! fn main() {
@@ -150,12 +151,14 @@
 //!         x0 = "cos(1.)"
 //!         t0 = 2
 //!         f = "sin(x)"
+//!         g = 2.5
 //!     "#;
 //!     let ode: Ode = toml::from_str(config).unwrap();
 //!
 //!     assert_eq!(ode.x0, 1f64.cos());
 //!     assert_eq!(ode.t0, 2f64);
 //!     assert_eq!(ode.f.bind("x").unwrap()(2.), 2f64.sin());
+//!     assert_eq!(ode.g.eval().unwrap(), 2.5f64);
 //! }
 //!
 //! ```
@@ -185,6 +188,11 @@ extern crate nom;
 extern crate fnv;
 #[cfg(feature = "serde")]
 extern crate serde;
+#[cfg_attr(all(test, feature = "serde"), macro_use)]
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_derive;
+#[cfg(test)]
+extern crate serde_json;
 #[cfg(test)]
 extern crate serde_test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,7 @@
 //!
 //! # Documentation
 //!
-//! - [Full API documentation (crates.io)](https://docs.rs/meval)
-//!
-//! - [Full API documentation (master)](http://rekka.github.io/meval-rs/meval/index.html)
+//! - [Full API documentation](https://docs.rs/meval)
 //!
 //! # Installation
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,9 @@ impl std::error::Error for Error {
         match *self {
             Error::UnknownVariable(_) => "unknown variable",
             Error::Function(_, _) => "function evaluation error",
-             Error::EvalError(_) => "eval error",
+            Error::EvalError(_) => "eval error",
             Error::ParseError(ref e) => e.description(),
-            Error::RPNError(ref e) => e.description()
+            Error::RPNError(ref e) => e.description(),
         }
     }
 
@@ -276,7 +276,7 @@ impl std::error::Error for Error {
             Error::ParseError(ref e) => Some(e),
             Error::RPNError(ref e) => Some(e),
             Error::Function(_, ref e) => Some(e),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,15 +233,15 @@ impl fmt::Display for Error {
                 write!(f, "Evaluation error: function `{}`: {}", name, e)
             }
             Error::ParseError(ref e) => {
-                try!(write!(f, "Parse error: "));
+                write!(f, "Parse error: ")?;
                 e.fmt(f)
             }
             Error::RPNError(ref e) => {
-                try!(write!(f, "RPN error: "));
+                write!(f, "RPN error: ")?;
                 e.fmt(f)
             }
             Error::EvalError(ref e) => {
-                try!(write!(f, "Eval error: "));
+                write!(f, "Eval error: ")?;
                 e.fmt(f)
             }
         }
@@ -261,17 +261,7 @@ impl From<RPNError> for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::UnknownVariable(_) => "unknown variable",
-            Error::Function(_, _) => "function evaluation error",
-            Error::EvalError(_) => "eval error",
-            Error::ParseError(ref e) => e.description(),
-            Error::RPNError(ref e) => e.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::ParseError(ref e) => Some(e),
             Error::RPNError(ref e) => Some(e),

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -214,8 +214,26 @@ mod tests {
             Ok(vec![Number(1.), Unary(Fact), Number(2.), Binary(Pow)])
         );
         assert_eq!(
-            to_rpn(&[Number(1.), Binary(Times), Number(2.), Unary(Fact)]),
-            Ok(vec![Number(1.), Number(2.), Unary(Fact), Binary(Times)])
+            to_rpn(&[
+                Number(1.), 
+                Unary(Fact), 
+                Binary(Div), 
+                LParen, 
+                Number(2.), 
+                Binary(Plus), 
+                Number(3.), 
+                RParen, 
+                Unary(Fact)
+            ]),
+            Ok(vec![
+                Number(1.), 
+                Unary(Fact), 
+                Number(2.), 
+                Number(3.), 
+                Binary(Plus), 
+                Unary(Fact), 
+                Binary(Div)
+            ])
         );
         assert_eq!(
             to_rpn(&[

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -215,23 +215,23 @@ mod tests {
         );
         assert_eq!(
             to_rpn(&[
-                Number(1.), 
-                Unary(Fact), 
-                Binary(Div), 
-                LParen, 
-                Number(2.), 
-                Binary(Plus), 
-                Number(3.), 
-                RParen, 
+                Number(1.),
+                Unary(Fact),
+                Binary(Div),
+                LParen,
+                Number(2.),
+                Binary(Plus),
+                Number(3.),
+                RParen,
                 Unary(Fact)
             ]),
             Ok(vec![
-                Number(1.), 
-                Unary(Fact), 
-                Number(2.), 
-                Number(3.), 
-                Binary(Plus), 
-                Unary(Fact), 
+                Number(1.),
+                Unary(Fact),
+                Number(2.),
+                Number(3.),
+                Binary(Plus),
+                Unary(Fact),
                 Binary(Div)
             ])
         );

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -72,9 +72,11 @@ fn prec_assoc(token: &Token) -> (u32, Associativity) {
             Plus | Minus => (1, Left),
             Times | Div | Rem => (2, Left),
             Pow => (4, Right),
+            _ => unimplemented!(),
         },
         Unary(op) => match op {
             Plus | Minus => (3, NA),
+            Fact => (5, NA),
             _ => unimplemented!(),
         },
         Var(_) | Number(_) | Func(..) | LParen | RParen | Comma => (0, NA),
@@ -206,6 +208,14 @@ mod tests {
         assert_eq!(
             to_rpn(&[Unary(Minus), Number(1.), Binary(Pow), Number(2.)]),
             Ok(vec![Number(1.), Number(2.), Binary(Pow), Unary(Minus)])
+        );
+        assert_eq!(
+            to_rpn(&[Number(1.), Unary(Fact), Binary(Pow), Number(2.)]),
+            Ok(vec![Number(1.), Unary(Fact), Number(2.), Binary(Pow)])
+        );
+        assert_eq!(
+            to_rpn(&[Number(1.), Binary(Times), Number(2.), Unary(Fact)]),
+            Ok(vec![Number(1.), Number(2.), Unary(Fact), Binary(Times)])
         );
         assert_eq!(
             to_rpn(&[

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -175,8 +175,7 @@ named!(float<usize>, chain!(
 fn exp(input: &[u8]) -> IResult<&[u8], Option<usize>> {
     use nom::IResult::*;
     match alt!(input, tag!("e") | tag!("E")) {
-        Incomplete(_) => Done(input, None),
-        Error(_) => Done(input, None),
+        Incomplete(_) | Error(_) => Done(input, None),
         Done(i, _) => {
             match chain!(i, s: alt!(tag!("+") | tag!("-"))? ~
                    e: digit_complete,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -57,7 +57,7 @@ pub enum Operation {
     Div,
     Rem,
     Pow,
-    Fact
+    Fact,
 }
 
 /// Expression tokens.
@@ -103,7 +103,10 @@ named!(
     )
 );
 
-named!(fact<Token>, chain!(tag!("!"), || Token::Unary(Operation::Fact)));
+named!(
+    fact<Token>,
+    chain!(tag!("!"), || Token::Unary(Operation::Fact))
+);
 named!(lparen<Token>, chain!(tag!("("), || Token::LParen));
 named!(rparen<Token>, chain!(tag!(")"), || Token::RParen));
 named!(comma<Token>, chain!(tag!(","), || Token::Comma));
@@ -125,7 +128,8 @@ fn ident(input: &[u8]) -> IResult<&[u8], &[u8]> {
                 .take_while(|&&c| match c {
                     b'a'...b'z' | b'A'...b'Z' | b'_' | b'0'...b'9' => true,
                     _ => false,
-                }).count();
+                })
+                .count();
             let (parsed, rest) = input.split_at(n + 1);
             Done(rest, parsed)
         }
@@ -234,7 +238,11 @@ named!(
 );
 named!(
     after_rexpr<Token>,
-    delimited!(opt!(multispace), alt!(fact | binop | rparen), opt!(multispace))
+    delimited!(
+        opt!(multispace),
+        alt!(fact | binop | rparen),
+        opt!(multispace)
+    )
 );
 named!(
     after_rexpr_no_paren<Token>,
@@ -505,7 +513,14 @@ mod tests {
 
         assert_eq!(
             tokenize("1 + 3! + 1"),
-            Ok(vec![Number(1f64), Binary(Plus), Number(3f64), Unary(Fact), Binary(Plus), Number(1f64)])
+            Ok(vec![
+                Number(1f64),
+                Binary(Plus),
+                Number(3f64),
+                Unary(Fact),
+                Binary(Plus),
+                Number(1f64)
+            ])
         );
 
         assert_eq!(tokenize("!3"), Err(ParseError::UnexpectedToken(0)));

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,8 +5,7 @@
 //! The parser should tokenize only well-formed expressions.
 //!
 //! [nom]: https://crates.io/crates/nom
-use nom::{multispace, slice_to_offsets, IResult, Needed};
-use std;
+use nom::{Needed, multispace, slice_to_offsets, IResult};
 use std::fmt;
 use std::str::from_utf8;
 
@@ -117,16 +116,16 @@ named!(comma<Token>, chain!(tag!(","), || Token::Comma));
 fn ident(input: &[u8]) -> IResult<&[u8], &[u8]> {
     use nom::Err::*;
     use nom::IResult::*;
-    use nom::{ErrorKind, Needed};
+    use nom::ErrorKind;
 
     // first character must be 'a'...'z' | 'A'...'Z' | '_'
     match input.first().cloned() {
-        Some(b'a'...b'z') | Some(b'A'...b'Z') | Some(b'_') => {
+        Some(b'a'..=b'z') | Some(b'A'..=b'Z') | Some(b'_') => {
             let n = input
                 .iter()
                 .skip(1)
                 .take_while(|&&c| match c {
-                    b'a'...b'z' | b'A'...b'Z' | b'_' | b'0'...b'9' => true,
+                    b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'0'..=b'9' => true,
                     _ => false,
                 })
                 .count();
@@ -145,7 +144,7 @@ named!(
     ))
 );
 
-/// Parse `func(`, returns `func`.
+// Parse `func(`, returns `func`.
 named!(
     func<Token>,
     map!(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,10 +5,10 @@
 //! The parser should tokenize only well-formed expressions.
 //!
 //! [nom]: https://crates.io/crates/nom
-use std::str::from_utf8;
-use nom::{IResult, Needed, multispace, slice_to_offsets};
-use std::fmt;
+use nom::{multispace, slice_to_offsets, IResult, Needed};
 use std;
+use std::fmt;
+use std::str::from_utf8;
 
 /// An error reported by the parser.
 #[derive(Debug, Clone, PartialEq)]
@@ -27,12 +27,12 @@ impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ParseError::UnexpectedToken(i) => write!(f, "Unexpected token at byte {}.", i),
-            ParseError::MissingRParen(i) => {
-                write!(f,
-                       "Missing {} right parenthes{}.",
-                       i,
-                       if i == 1 { "is" } else { "es" })
-            }
+            ParseError::MissingRParen(i) => write!(
+                f,
+                "Missing {} right parenthes{}.",
+                i,
+                if i == 1 { "is" } else { "es" }
+            ),
             ParseError::MissingArgument => write!(f, "Missing argument at the end of expression."),
         }
     }
@@ -82,48 +82,48 @@ pub enum Token {
     Func(String, Option<usize>),
 }
 
-named!(binop<Token>, alt!(
-    chain!(tag!("+"),||{Token::Binary(Operation::Plus)}) |
-    chain!(tag!("-"),||{Token::Binary(Operation::Minus)}) |
-    chain!(tag!("*"),||{Token::Binary(Operation::Times)}) |
-    chain!(tag!("/"),||{Token::Binary(Operation::Div)}) |
-    chain!(tag!("%"),||{Token::Binary(Operation::Rem)}) |
-    chain!(tag!("^"),||{Token::Binary(Operation::Pow)})
+named!(
+    binop<Token>,
+    alt!(
+        chain!(tag!("+"), || Token::Binary(Operation::Plus))
+            | chain!(tag!("-"), || Token::Binary(Operation::Minus))
+            | chain!(tag!("*"), || Token::Binary(Operation::Times))
+            | chain!(tag!("/"), || Token::Binary(Operation::Div))
+            | chain!(tag!("%"), || Token::Binary(Operation::Rem))
+            | chain!(tag!("^"), || Token::Binary(Operation::Pow))
     )
 );
 
-named!(unop<Token>, alt!(
-    chain!(tag!("+"),||{Token::Unary(Operation::Plus)}) |
-    chain!(tag!("-"),||{Token::Unary(Operation::Minus)})
+named!(
+    unop<Token>,
+    alt!(
+        chain!(tag!("+"), || Token::Unary(Operation::Plus))
+            | chain!(tag!("-"), || Token::Unary(Operation::Minus))
     )
 );
 
-named!(lparen<Token>, chain!(tag!("("),||{Token::LParen}));
-named!(rparen<Token>, chain!(tag!(")"),||{Token::RParen}));
-named!(comma<Token>, chain!(tag!(","),||{Token::Comma}));
+named!(lparen<Token>, chain!(tag!("("), || Token::LParen));
+named!(rparen<Token>, chain!(tag!(")"), || Token::RParen));
+named!(comma<Token>, chain!(tag!(","), || Token::Comma));
 
 /// Parse an identifier:
 ///
 /// Must start with a letter or an underscore, can be followed by letters, digits or underscores.
 fn ident(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    use nom::IResult::*;
-    use nom::{Needed, ErrorKind};
     use nom::Err::*;
+    use nom::IResult::*;
+    use nom::{ErrorKind, Needed};
 
     // first character must be 'a'...'z' | 'A'...'Z' | '_'
     match input.first().cloned() {
-        Some(b'a'...b'z') |
-        Some(b'A'...b'Z') |
-        Some(b'_') => {
-            let n = input.iter()
+        Some(b'a'...b'z') | Some(b'A'...b'Z') | Some(b'_') => {
+            let n = input
+                .iter()
                 .skip(1)
-                .take_while(|&&c| {
-                    match c {
-                        b'a'...b'z' | b'A'...b'Z' | b'_' | b'0'...b'9' => true,
-                        _ => false,
-                    }
-                })
-                .count();
+                .take_while(|&&c| match c {
+                    b'a'...b'z' | b'A'...b'Z' | b'_' | b'0'...b'9' => true,
+                    _ => false,
+                }).count();
             let (parsed, rest) = input.split_at(n + 1);
             Done(rest, parsed)
         }
@@ -132,15 +132,27 @@ fn ident(input: &[u8]) -> IResult<&[u8], &[u8]> {
     }
 }
 
-named!(var<Token>, map!(map_res!(complete!(ident), from_utf8), |s: &str| Token::Var(s.into())));
+named!(
+    var<Token>,
+    map!(map_res!(complete!(ident), from_utf8), |s: &str| Token::Var(
+        s.into()
+    ))
+);
 
 /// Parse `func(`, returns `func`.
-named!(func<Token>, map!(map_res!(
-            terminated!(complete!(ident),
-                        preceded!(opt!(multispace), complete!(tag!("(")))), from_utf8),
-            |s: &str| Token::Func(s.into(), None)
-            )
-      );
+named!(
+    func<Token>,
+    map!(
+        map_res!(
+            terminated!(
+                complete!(ident),
+                preceded!(opt!(multispace), complete!(tag!("(")))
+            ),
+            from_utf8
+        ),
+        |s: &str| Token::Func(s.into(), None)
+    )
+);
 
 /// Matches one or more digit characters `0`...`9`.
 ///
@@ -148,9 +160,9 @@ named!(func<Token>, map!(map_res!(
 ///
 /// Fix of IMHO broken `nom::digit`, which parses an empty string successfully.
 fn digit_complete(input: &[u8]) -> IResult<&[u8], &[u8]> {
+    use nom::Err::*;
     use nom::IResult::*;
     use nom::{is_digit, ErrorKind};
-    use nom::Err::*;
 
     let n = input.iter().take_while(|&&c| is_digit(c)).count();
     if n > 0 {
@@ -161,7 +173,9 @@ fn digit_complete(input: &[u8]) -> IResult<&[u8], &[u8]> {
     }
 }
 
-named!(float<usize>, chain!(
+named!(
+    float<usize>,
+    chain!(
         a: digit_complete ~
         b: complete!(chain!(tag!(".") ~ d: digit_complete?,
                             ||{1 + d.map(|s| s.len()).unwrap_or(0)}))? ~
@@ -176,22 +190,21 @@ fn exp(input: &[u8]) -> IResult<&[u8], Option<usize>> {
     use nom::IResult::*;
     match alt!(input, tag!("e") | tag!("E")) {
         Incomplete(_) | Error(_) => Done(input, None),
-        Done(i, _) => {
-            match chain!(i, s: alt!(tag!("+") | tag!("-"))? ~
+        Done(i, _) => match chain!(i, s: alt!(tag!("+") | tag!("-"))? ~
                    e: digit_complete,
-                ||{Some(1 + s.map(|s| s.len()).unwrap_or(0) + e.len())}) {
-                Incomplete(Needed::Size(i)) => Incomplete(Needed::Size(i + 1)),
-                o => o,
-            }
-        }
+                ||{Some(1 + s.map(|s| s.len()).unwrap_or(0) + e.len())})
+        {
+            Incomplete(Needed::Size(i)) => Incomplete(Needed::Size(i + 1)),
+            o => o,
+        },
     }
 }
 
 fn number(input: &[u8]) -> IResult<&[u8], Token> {
-    use nom::IResult::*;
     use nom::Err;
-    use std::str::FromStr;
     use nom::ErrorKind;
+    use nom::IResult::*;
+    use std::str::FromStr;
 
     match float(input) {
         Done(rest, l) => {
@@ -200,26 +213,39 @@ fn number(input: &[u8]) -> IResult<&[u8], Token> {
             from_utf8(&input[..l])
                 .ok()
                 .and_then(|s| f64::from_str(s).ok())
-                .map_or(Error(Err::Position(ErrorKind::Custom(0), input)),
-                        |f| Done(rest, Token::Number(f)))
+                .map_or(Error(Err::Position(ErrorKind::Custom(0), input)), |f| {
+                    Done(rest, Token::Number(f))
+                })
         }
         Error(e) => Error(e),
         Incomplete(n) => Incomplete(n),
     }
 }
 
-named!(lexpr<Token>, delimited!(opt!(multispace),
-                                alt!(number | func | var | unop | lparen),
-                                opt!(multispace)));
-named!(after_rexpr<Token>, delimited!(opt!(multispace),
-                                      alt!(binop | rparen),
-                                      opt!(multispace)));
-named!(after_rexpr_no_paren<Token>, delimited!(opt!(multispace),
-                                               alt!(binop),
-                                               opt!(multispace)));
-named!(after_rexpr_comma<Token>, delimited!(opt!(multispace),
-                                      alt!(binop | rparen | comma),
-                                      opt!(multispace)));
+named!(
+    lexpr<Token>,
+    delimited!(
+        opt!(multispace),
+        alt!(number | func | var | unop | lparen),
+        opt!(multispace)
+    )
+);
+named!(
+    after_rexpr<Token>,
+    delimited!(opt!(multispace), alt!(binop | rparen), opt!(multispace))
+);
+named!(
+    after_rexpr_no_paren<Token>,
+    delimited!(opt!(multispace), alt!(binop), opt!(multispace))
+);
+named!(
+    after_rexpr_comma<Token>,
+    delimited!(
+        opt!(multispace),
+        alt!(binop | rparen | comma),
+        opt!(multispace)
+    )
+);
 
 #[derive(Debug, Clone, Copy)]
 enum TokenizerState {
@@ -244,8 +270,8 @@ enum ParenState {
 /// Returns `Err` if the expression is not well-formed.
 pub fn tokenize<S: AsRef<str>>(input: S) -> Result<Vec<Token>, ParseError> {
     use self::TokenizerState::*;
-    use nom::IResult::*;
     use nom::Err;
+    use nom::IResult::*;
     let mut state = LExpr;
     // number of function arguments left
     let mut paren_stack = vec![];
@@ -291,10 +317,12 @@ pub fn tokenize<S: AsRef<str>>(input: S) -> Result<Vec<Token>, ParseError> {
                 return Err(ParseError::UnexpectedToken(i));
             }
             _ => {
-                panic!("Unexpected parse result when parsing `{}` at `{}`: {:?}",
-                       String::from_utf8_lossy(input),
-                       String::from_utf8_lossy(s),
-                       r);
+                panic!(
+                    "Unexpected parse result when parsing `{}` at `{}`: {:?}",
+                    String::from_utf8_lossy(input),
+                    String::from_utf8_lossy(s),
+                    r
+                );
             }
         }
     }
@@ -309,30 +337,42 @@ pub fn tokenize<S: AsRef<str>>(input: S) -> Result<Vec<Token>, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::{number, binop, var, func};
-    use nom::IResult;
-    use nom::ErrorKind::*;
+    use super::{binop, func, number, var};
     use nom::Err::*;
+    use nom::ErrorKind::*;
+    use nom::IResult;
 
     #[test]
     fn it_works() {
-        assert_eq!(binop(b"+"),
-                   IResult::Done(&b""[..], Token::Binary(Operation::Plus)));
-        assert_eq!(number(b"32143"),
-                   IResult::Done(&b""[..], Token::Number(32143f64)));
-        assert_eq!(var(b"abc"),
-                   IResult::Done(&b""[..], Token::Var("abc".into())));
-        assert_eq!(func(b"abc("),
-                   IResult::Done(&b""[..], Token::Func("abc".into(), None)));
-        assert_eq!(func(b"abc ("),
-                   IResult::Done(&b""[..], Token::Func("abc".into(), None)));
+        assert_eq!(
+            binop(b"+"),
+            IResult::Done(&b""[..], Token::Binary(Operation::Plus))
+        );
+        assert_eq!(
+            number(b"32143"),
+            IResult::Done(&b""[..], Token::Number(32143f64))
+        );
+        assert_eq!(
+            var(b"abc"),
+            IResult::Done(&b""[..], Token::Var("abc".into()))
+        );
+        assert_eq!(
+            func(b"abc("),
+            IResult::Done(&b""[..], Token::Func("abc".into(), None))
+        );
+        assert_eq!(
+            func(b"abc ("),
+            IResult::Done(&b""[..], Token::Func("abc".into(), None))
+        );
     }
 
     #[test]
     fn test_var() {
         for &s in ["abc", "U0", "_034", "a_be45EA", "aAzZ_"].iter() {
-            assert_eq!(var(s.as_bytes()),
-                       IResult::Done(&b""[..], Token::Var(s.into())));
+            assert_eq!(
+                var(s.as_bytes()),
+                IResult::Done(&b""[..], Token::Var(s.into()))
+            );
         }
 
         assert_eq!(var(b""), IResult::Error(Position(Complete, &b""[..])));
@@ -342,9 +382,13 @@ mod tests {
     #[test]
     fn test_func() {
         for &s in ["abc(", "u0(", "_034 (", "A_be45EA  ("].iter() {
-            assert_eq!(func(s.as_bytes()),
-                       IResult::Done(&b""[..],
-                                     Token::Func((&s[0..s.len() - 1]).trim().into(), None)));
+            assert_eq!(
+                func(s.as_bytes()),
+                IResult::Done(
+                    &b""[..],
+                    Token::Func((&s[0..s.len() - 1]).trim().into(), None)
+                )
+            );
         }
 
         assert_eq!(func(b""), IResult::Error(Position(Complete, &b""[..])));
@@ -354,18 +398,30 @@ mod tests {
 
     #[test]
     fn test_number() {
-        assert_eq!(number(b"32143"),
-                   IResult::Done(&b""[..], Token::Number(32143f64)));
-        assert_eq!(number(b"2."),
-                   IResult::Done(&b""[..], Token::Number(2.0f64)));
-        assert_eq!(number(b"32143.25"),
-                   IResult::Done(&b""[..], Token::Number(32143.25f64)));
-        assert_eq!(number(b"0.125e9"),
-                   IResult::Done(&b""[..], Token::Number(0.125e9f64)));
-        assert_eq!(number(b"20.5E-3"),
-                   IResult::Done(&b""[..], Token::Number(20.5E-3f64)));
-        assert_eq!(number(b"123423e+50"),
-                   IResult::Done(&b""[..], Token::Number(123423e+50f64)));
+        assert_eq!(
+            number(b"32143"),
+            IResult::Done(&b""[..], Token::Number(32143f64))
+        );
+        assert_eq!(
+            number(b"2."),
+            IResult::Done(&b""[..], Token::Number(2.0f64))
+        );
+        assert_eq!(
+            number(b"32143.25"),
+            IResult::Done(&b""[..], Token::Number(32143.25f64))
+        );
+        assert_eq!(
+            number(b"0.125e9"),
+            IResult::Done(&b""[..], Token::Number(0.125e9f64))
+        );
+        assert_eq!(
+            number(b"20.5E-3"),
+            IResult::Done(&b""[..], Token::Number(20.5E-3f64))
+        );
+        assert_eq!(
+            number(b"123423e+50"),
+            IResult::Done(&b""[..], Token::Number(123423e+50f64))
+        );
 
         assert_eq!(number(b""), IResult::Error(Position(Digit, &b""[..])));
         assert_eq!(number(b".2"), IResult::Error(Position(Digit, &b".2"[..])));
@@ -377,61 +433,73 @@ mod tests {
 
     #[test]
     fn test_tokenize() {
-        use super::Token::*;
         use super::Operation::*;
+        use super::Token::*;
 
         assert_eq!(tokenize("a"), Ok(vec![Var("a".into())]));
 
-        assert_eq!(tokenize("2 +(3--2) "),
-                   Ok(vec![Number(2f64),
-                           Binary(Plus),
-                           LParen,
-                           Number(3f64),
-                           Binary(Minus),
-                           Unary(Minus),
-                           Number(2f64),
-                           RParen]));
+        assert_eq!(
+            tokenize("2 +(3--2) "),
+            Ok(vec![
+                Number(2f64),
+                Binary(Plus),
+                LParen,
+                Number(3f64),
+                Binary(Minus),
+                Unary(Minus),
+                Number(2f64),
+                RParen
+            ])
+        );
 
-        assert_eq!(tokenize("-2^ ab0 *12 - C_0"),
-                   Ok(vec![Unary(Minus),
-                           Number(2f64),
-                           Binary(Pow),
-                           Var("ab0".into()),
-                           Binary(Times),
-                           Number(12f64),
-                           Binary(Minus),
-                           Var("C_0".into()),
-                   ]));
+        assert_eq!(
+            tokenize("-2^ ab0 *12 - C_0"),
+            Ok(vec![
+                Unary(Minus),
+                Number(2f64),
+                Binary(Pow),
+                Var("ab0".into()),
+                Binary(Times),
+                Number(12f64),
+                Binary(Minus),
+                Var("C_0".into()),
+            ])
+        );
 
-        assert_eq!(tokenize("-sin(pi * 3)^ cos(2) / Func2(x, f(y), z) * _buildIN(y)"),
-                   Ok(vec![Unary(Minus),
-                           Func("sin".into(), None),
-                           Var("pi".into()),
-                           Binary(Times),
-                           Number(3f64),
-                           RParen,
-                           Binary(Pow),
-                           Func("cos".into(), None),
-                           Number(2f64),
-                           RParen,
-                           Binary(Div),
-                           Func("Func2".into(), None),
-                           Var("x".into()),
-                           Comma,
-                           Func("f".into(), None),
-                           Var("y".into()),
-                           RParen,
-                           Comma,
-                           Var("z".into()),
-                           RParen,
-                           Binary(Times),
-                           Func("_buildIN".into(), None),
-                           Var("y".into()),
-                           RParen,
-                       ]));
+        assert_eq!(
+            tokenize("-sin(pi * 3)^ cos(2) / Func2(x, f(y), z) * _buildIN(y)"),
+            Ok(vec![
+                Unary(Minus),
+                Func("sin".into(), None),
+                Var("pi".into()),
+                Binary(Times),
+                Number(3f64),
+                RParen,
+                Binary(Pow),
+                Func("cos".into(), None),
+                Number(2f64),
+                RParen,
+                Binary(Div),
+                Func("Func2".into(), None),
+                Var("x".into()),
+                Comma,
+                Func("f".into(), None),
+                Var("y".into()),
+                RParen,
+                Comma,
+                Var("z".into()),
+                RParen,
+                Binary(Times),
+                Func("_buildIN".into(), None),
+                Var("y".into()),
+                RParen,
+            ])
+        );
 
-        assert_eq!(tokenize("2 % 3"),
-                   Ok(vec![Number(2f64), Binary(Rem), Number(3f64)]));
+        assert_eq!(
+            tokenize("2 % 3"),
+            Ok(vec![Number(2f64), Binary(Rem), Number(3f64)])
+        );
 
         assert_eq!(tokenize("()"), Err(ParseError::UnexpectedToken(1)));
 


### PR DESCRIPTION
In Detail
- 1. Removed impl for describe method or meval::error::Error
- 2. changed try!() to ? operator
- 3. changed ... 's in tokenizer.rs to ..= 's in line 129 and 124
- 4. removed redundant import of nom::Needed
- 5. converted un-generated doc to comment line 148
- 6. changed mentions of traits to ``dyn`` trait